### PR TITLE
Use relative, generic topic names for all topics

### DIFF
--- a/gps_publisher/README.md
+++ b/gps_publisher/README.md
@@ -22,7 +22,7 @@ Covariance is filled using u-blox accuracy fields:
 - `hAcc` / `vAcc` (mm → meters → meters²), published as diagonal covariance.
 
 ## Published Topics
-`gps/raw` (`sensor_msgs/NavSatFix`) - processed GPS fix messages
+`gps` (`sensor_msgs/NavSatFix`) - processed GPS fix messages
 
 ## GPS Configurations
 > Note: Message “rate” in `CFG-MSG` is **messages per navigation cycle**.  

--- a/state_machine/README.md
+++ b/state_machine/README.md
@@ -15,11 +15,11 @@ There are three mutually exclusive states:
 4. Late-joining subscribers immediately receive the most recent state
 
 ## Published Topics
-`/state` (`std_msgs/String`) - The current robot state as one of `"normal"`,  `"ramp"`, or `"recovery"`
+`state` (`std_msgs/String`) - The current robot state as one of `"normal"`,  `"ramp"`, or `"recovery"`
 
 ## Services
-`/state/set_ramp` (`std_srvs/SetBool`) - Enable or disable ramp mode.  
-`/state/set_recovery` (`std_srvs/SetBool`) - Enable or disable recovery mode.
+`state/set_ramp` (`std_srvs/SetBool`) - Enable or disable ramp mode.  
+`state/set_recovery` (`std_srvs/SetBool`) - Enable or disable recovery mode.
 
 ## Example Usage
 

--- a/state_machine/state_machine/state_machine.py
+++ b/state_machine/state_machine/state_machine.py
@@ -24,7 +24,7 @@ class StateMachine(Node):
     def __init__(self) -> None:
         super().__init__("state_machine")
 
-        self.publisher = self.create_publisher(String, "/state", QoSProfile(
+        self.publisher = self.create_publisher(String, "state", QoSProfile(
             history=QoSHistoryPolicy.KEEP_LAST,
             depth=1,
             reliability=QoSReliabilityPolicy.RELIABLE,
@@ -33,10 +33,10 @@ class StateMachine(Node):
 
         self.last_state: Optional[State] = None
 
-        self.set_ramp_service = self.create_service(SetBool, "/state/set_ramp", self.set_ramp_callback)
+        self.set_ramp_service = self.create_service(SetBool, "state/set_ramp", self.set_ramp_callback)
         self.ramp_enabled = False
 
-        self.set_recovery_service = self.create_service(SetBool, "/state/set_recovery", self.set_recovery_callback)
+        self.set_recovery_service = self.create_service(SetBool, "state/set_recovery", self.set_recovery_callback)
         self.recovery_enabled = False
 
         self.publish_state_if_changed(reason="init")
@@ -70,7 +70,7 @@ class StateMachine(Node):
         self.recovery_enabled = req.data
         res.success = True
         self.get_logger().info(res.message + f" (ramp_enabled={self.ramp_enabled})")
-        self.publish_state_if_changed(reason="/state/set_recovery")
+        self.publish_state_if_changed(reason="state/set_recovery")
         return res
 
     def set_ramp_callback(self, req: SetBool.Request, res: SetBool.Response) -> SetBool.Response:
@@ -82,7 +82,7 @@ class StateMachine(Node):
         self.ramp_enabled = req.data
         res.success = True
         self.get_logger().info(res.message + f" (recovery_enabled={self.recovery_enabled})")
-        self.publish_state_if_changed(reason="/state/set_ramp")
+        self.publish_state_if_changed(reason="state/set_ramp")
         return res
 
 def main() -> None:


### PR DESCRIPTION
## What has changed
Change topic names and associated docs to use relative topic names so they are self contained. Specific topic names can be remapped