### PR TITLE
Make CellState continuous and expose value

### DIFF
--- a/nav_utils/README.md
+++ b/nav_utils/README.md
@@ -62,7 +62,7 @@ World-facing wrapper around a robot-centric `nav_msgs/msg/OccupancyGrid`.
 This class provides a world-coordinate view of a discrete, robot-centric occupancy grid. 
 
 It allows planners to operate entirely on world `Point`s—querying occupancy, expanding neighbors, and hashing locations—without directly interacting with grid indices. Conceptually, the occupancy grid is treated as an infinite world representation:
-world points are projected into grid cells on demand, and any point outside the underlying grid bounds is treated as `UNKNOWN`.
+world points are projected into grid cells on demand, and any point outside the underlying grid bounds is treated as unknown
 
 #### Conventions / Transformations
 This assumes that the occupancy grid is centered at the robot and begins `robot_forward_offset_m` meters in front of the robot. The input `OccupancyGrid.data` is interpreted as column-major, with index 0 corresponding to the top-left cell.
@@ -73,7 +73,7 @@ Internally, the occupancy grid is transformed into a robot-aligned coordinate sy
 - the grid origin is the bottom-left corner of the grid
 
 #### State
-State of the occupancy grid at some point can be queried using `state(point)`. The state is treated as `CellState.UNKNOWN` if `(grid_x, grid_y)` lies outside `[0..width) × [0..height)`.
+State of the occupancy grid at some point can be queried using `state(point)`. `state.unknown` is true if `(grid_x, grid_y)` lies outside `[0..width) × [0..height)`.
 
 #### Discrete “search” in continuous space via neighbors
 Although planner code operates on continuous world `Point`s, discrete graph search can still be performed using `neighbors4(point)`, `neighbors8(point)`, or `neighbors_forward(point)`.

--- a/nav_utils/test/test_world_occupancy_grid.py
+++ b/nav_utils/test/test_world_occupancy_grid.py
@@ -56,7 +56,7 @@ def test_grid_index_center_to_world():
 
 def test_state():
     matrix = np.zeros((6, 6), dtype=np.int8)
-    matrix[4, 3] = CellState.OCCUPIED
+    matrix[4, 3] = 100
     
     grid = WorldOccupancyGrid(
         grid=make_grid_from_target_matrix(matrix, resolution=0.5), 
@@ -64,9 +64,9 @@ def test_state():
         robot_forward_offset_m=0.6
     )
 
-    assert grid.state(Point(x=2.5, y=2.0, z=0.0)) == CellState.FREE
-    assert grid.state(Point(x=3.25, y=3.5, z=0.0)) == CellState.OCCUPIED
-    assert grid.state(Point(x=2.0, y=1.0, z=0.0)) == CellState.UNKNOWN
+    assert grid.state(Point(x=2.5, y=2.0, z=0.0)).drivable
+    assert not grid.state(Point(x=3.25, y=3.5, z=0.0)).drivable
+    assert grid.state(Point(x=2.0, y=1.0, z=0.0)).unknown
 
 def test_neighbors():
     grid = WorldOccupancyGrid(

--- a/nav_utils/test/test_world_occupancy_grid.py
+++ b/nav_utils/test/test_world_occupancy_grid.py
@@ -41,8 +41,8 @@ def test_world_to_grid_index():
         robot_forward_offset_m=0.6
     )
 
-    assert grid.world_to_grid_index(Point(x=3.25, y=3.5, z=0.0)) == (4, 3)
-    assert grid.world_to_grid_index(Point(x=2.0, y=1.0, z=0.0)) == (-1, 0)
+    assert grid._world_to_grid_index(Point(x=3.25, y=3.5, z=0.0)) == (4, 3)
+    assert grid._world_to_grid_index(Point(x=2.0, y=1.0, z=0.0)) == (-1, 0)
 
 def test_grid_index_center_to_world():
     grid = WorldOccupancyGrid(
@@ -51,8 +51,8 @@ def test_grid_index_center_to_world():
         robot_forward_offset_m=0.6
     )
 
-    assert point_is_close(grid.grid_index_center_to_world(2, 0), Point(x=3.2271, y=1.8425, z=0.0))
-    assert point_is_close(grid.grid_index_center_to_world(2, -1), Point(x=3.4771, y=1.4095, z=0.0))
+    assert point_is_close(grid._grid_index_center_to_world(2, 0), Point(x=3.2271, y=1.8425, z=0.0))
+    assert point_is_close(grid._grid_index_center_to_world(2, -1), Point(x=3.4771, y=1.4095, z=0.0))
 
 def test_state():
     matrix = np.zeros((6, 6), dtype=np.int8)
@@ -76,15 +76,15 @@ def test_neighbors():
     )
 
     point = Point(x=3.25, y=3.5, z=0.0)
-    assert grid.world_to_grid_index(point) == (4, 3)
+    assert grid._world_to_grid_index(point) == (4, 3)
 
     neighbors4 = list(grid.neighbors4(point))
     assert len(neighbors4) == 4
-    assert {grid.world_to_grid_index(q) for q in neighbors4} == {(5, 3), (4, 4), (4, 2), (3, 3)}
+    assert {grid._world_to_grid_index(q) for q in neighbors4} == {(5, 3), (4, 4), (4, 2), (3, 3)}
 
     neighbors8 = list(grid.neighbors8(point))
     assert len(neighbors8) == 8
-    assert {grid.world_to_grid_index(q) for q in neighbors8} == {
+    assert {grid._world_to_grid_index(q) for q in neighbors8} == {
         (3, 2), (4, 2), (5, 2),
         (3, 3),         (5, 3),
         (3, 4), (4, 4), (5, 4),
@@ -92,7 +92,7 @@ def test_neighbors():
 
     neighbors_forward = list(grid.neighbors_forward(point))
     assert len(neighbors_forward) == 5
-    assert [grid.world_to_grid_index(q) for q in neighbors_forward] == [
+    assert [grid._world_to_grid_index(q) for q in neighbors_forward] == [
         (5, 3),  # forward
         (5, 4),  # forward-left
         (5, 2),  # forward-right
@@ -123,8 +123,8 @@ def test_hash_key_unique_indices():
 
     keys = []
     for ix, iy in indices:
-        world = grid.grid_index_center_to_world(ix, iy)
-        assert grid.world_to_grid_index(world) == (ix, iy)
+        world = grid._grid_index_center_to_world(ix, iy)
+        assert grid._world_to_grid_index(world) == (ix, iy)
         keys.append(grid.hash_key(world))
 
     assert len(set(keys)) == len(keys)


### PR DESCRIPTION
## What has changed
Instead of CellState being an enum with `UNKNOWN`, `FREE`, and `OCCUPIED`, CellState now stores the actual occupancy grid value from -1 to 100. Drivability and unknown is computed using the grid value. This is done because the inflation layer now does decay and may have values that is not 0, -1 or 100. Path planning also wants to use the occupancy grid value as its heuristic

## Testing plan
Passes unit test