### PR TITLE
Make CellState continuous and expose value

### DIFF
--- a/nav_utils/README.md
+++ b/nav_utils/README.md
@@ -60,7 +60,7 @@ class Planner(Node):
 This class provides a world-coordinate view of a discrete, robot-centric occupancy grid. 
 
 It allows planners to operate entirely on world `Point`s—querying occupancy, expanding neighbors, and hashing locations—without directly interacting with grid indices. Conceptually, the occupancy grid is treated as an infinite world representation:
-world points are projected into grid cells on demand, and any point outside the underlying grid bounds is treated as `UNKNOWN`.
+world points are projected into grid cells on demand, and any point outside the underlying grid bounds is treated as unknown
 
 #### Conventions / Transformations
 The supplied occupancy grid is assumed to have the following conventions (matching odom conventions):
@@ -70,7 +70,7 @@ The supplied occupancy grid is assumed to have the following conventions (matchi
 - data is row major
 
 #### State
-State of the occupancy grid at some point can be queried using `state(point)`. The state is treated as `CellState.UNKNOWN` if `(grid_x, grid_y)` lies outside `[0..width) × [0..height)`.
+State of the occupancy grid at some point can be queried using `state(point)`. `state.unknown` is true if `(grid_x, grid_y)` lies outside `[0..width) × [0..height)`.
 
 #### Discrete “search” in continuous space via neighbors
 Although planner code operates on continuous world `Point`s, discrete graph search can still be performed using `neighbors4(point)`, `neighbors8(point)`, or `neighbors_forward(point)`.

--- a/nav_utils/README.md
+++ b/nav_utils/README.md
@@ -60,7 +60,7 @@ class Planner(Node):
 This class provides a world-coordinate view of a discrete, robot-centric occupancy grid. 
 
 It allows planners to operate entirely on world `Point`s—querying occupancy, expanding neighbors, and hashing locations—without directly interacting with grid indices. Conceptually, the occupancy grid is treated as an infinite world representation:
-world points are projected into grid cells on demand, and any point outside the underlying grid bounds is treated as unknown
+world points are projected into grid cells on demand, and any point outside the underlying grid bounds is treated as unknown.
 
 #### Conventions / Transformations
 The supplied occupancy grid is assumed to have the following conventions (matching odom conventions):

--- a/nav_utils/nav_utils/world_occupancy_grid.py
+++ b/nav_utils/nav_utils/world_occupancy_grid.py
@@ -2,54 +2,33 @@ from nav_msgs.msg import OccupancyGrid
 from geometry_msgs.msg import Point
 import math
 from typing import Iterator
-from enum import IntEnum
+from dataclasses import dataclass
 from nav_utils.geometry import get_yaw_radians_from_quaternion, rotate_by_yaw
 
-class CellState(IntEnum):
+@dataclass(frozen=True)
+class CellState:
     """
     Discrete occupancy state of a grid cell.
-
-    Values follow the ROS occupancy grid convention:
-    - UNKNOWN  (-1): Cell occupancy is unknown or outside the grid bounds.
-    - FREE      (0): Cell is known to be free and traversable.
-    - OCCUPIED (1): Cell is occupied by an obstacle.
-
-    This enum provides a semantic layer over raw occupancy values and is used throughout planning code to reason about 
-    traversability.
     """
-    
-    UNKNOWN    = -1
-    FREE       = 0
-    OCCUPIED   = 1
+    value: int  # -1 (unknown) or 0–100 (probability occupied)
 
-    @staticmethod
-    def from_occupancy(value: int) -> "CellState":
-        """
-        Classify a raw ROS occupancy value into a CellState.
-
-        Returns:
-            UNKNOWN if value is -1, FREE if value is 0, OCCUPIED if value is between 1 and 100
-        """
-        if value == -1:
-            return CellState.UNKNOWN
-        
-        if value == 0:
-            return CellState.FREE
-        
-        if 1 <= value <= 100:
-            return CellState.OCCUPIED
-        
-        raise ValueError(f"Invalid occupancy value: {value} (expected -1, 0, or 1..100)")
+    def __post_init__(self) -> None:
+        if not (-1 <= self.value <= 100):
+            raise ValueError("CellState value must be in range [-1, 100]")
 
     @property
     def drivable(self) -> bool:
         """
-        Whether this cell can be traversed by the robot.
-
-        Returns: 
-            True if the cell state is FREE. UNKNOWN and OCCUPIED grids are treated as non-drivable.
+        True if the cell can be traversed by the robot
         """
-        return self == CellState.FREE
+        return 0 <= self.value <= 30
+
+    @property
+    def unknown(self) -> bool:
+        """
+        True if the cell value is unknown
+        """
+        return self.value == -1
 
 class WorldOccupancyGrid:
     """
@@ -102,9 +81,9 @@ class WorldOccupancyGrid:
         grid_x, grid_y = self._world_to_grid_index(point)
 
         if not(0 <= grid_x < self._occupancy_grid.info.width and 0 <= grid_y < self._occupancy_grid.info.height):
-            return CellState.UNKNOWN
+            return  CellState(-1)
 
-        return CellState.from_occupancy(self._occupancy_grid.data[grid_y * self._occupancy_grid.info.width + grid_x])
+        return CellState(self._occupancy_grid.data[grid_y * self._occupancy_grid.info.width + grid_x])
 
     def neighbors4(self, point: Point) -> Iterator[Point]:
         """

--- a/nav_utils/test/test_world_occupancy_grid.py
+++ b/nav_utils/test/test_world_occupancy_grid.py
@@ -34,13 +34,13 @@ def test_grid_index_center_to_world():
 
 def test_state():
     occupancy_grid = make_occupancy_grid()
-    occupancy_grid.data[22] = CellState.OCCUPIED
+    occupancy_grid.data[22] = 100
     
     grid = WorldOccupancyGrid(occupancy_grid)
 
-    assert grid.state(Point(x=2.5, y=2.0, z=0.0)) == CellState.FREE
-    assert grid.state(Point(x=3.25, y=3.5, z=0.0)) == CellState.OCCUPIED
-    assert grid.state(Point(x=2.0, y=1.0, z=0.0)) == CellState.UNKNOWN
+    assert grid.state(Point(x=2.5, y=2.0, z=0.0)).drivable
+    assert not grid.state(Point(x=3.25, y=3.5, z=0.0)).drivable
+    assert grid.state(Point(x=2.0, y=1.0, z=0.0)).unknown
 
 def test_neighbors():
     grid = WorldOccupancyGrid(make_occupancy_grid())


### PR DESCRIPTION
## What has changed
Instead of CellState being an enum with `UNKNOWN`, `FREE`, and `OCCUPIED`, CellState now stores the actual occupancy grid value from -1 to 100. Drivability and unknown is computed using the grid value. This is done because the inflation layer now does decay and may have values that is not 0, -1 or 100. Path planning also wants to use the occupancy grid value as its heuristic

## Testing plan
Passes unit test