### PR TITLE
Add border and use tf for transform for occupancy_grid_transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ The following describes how to run the point simulator (basic non-physics based 
 1. Publish an empty occupancy grid repeatedly:
     ```bash
     ros2 topic pub -r 1 /occ_grid nav_msgs/msg/OccupancyGrid "header:
-      frame_id: 'odom'
+      frame_id: 'base_link'
     info:
       resolution: 0.05
       width: 100
       height: 100
       origin:
-        position: {x: 0.0, y: 0.0, z: 0.0}
+        position: {x: 0.6, y: -2.5, z: 0.0}
         orientation: {x: 0.0, y: 0.0, z: 0.0, w: 1.0}
     data: [$(python3 -c 'print(", ".join(["0"]*100*100))')]"
     ```

--- a/nav_infrastructure_launch/launch/infra.launch.py
+++ b/nav_infrastructure_launch/launch/infra.launch.py
@@ -26,7 +26,7 @@ def generate_launch_description():
                 name="occupancy_grid_transform",
                 remappings=[
                     ("occupancy_grid", "occ_grid"),
-                    ("occupancy_grid_transform", "inflated_occupancy_grid"),
+                    ("transformed_occupancy_grid", "inflated_occupancy_grid"),
                 ],
             ),
             Node(package="path_tracking", executable="pure_pursuit", name="pure_pursuit"),

--- a/occupancy_grid_transform/README.md
+++ b/occupancy_grid_transform/README.md
@@ -1,13 +1,14 @@
 ## occupancy_grid_transform
-This package consumes the occupancy grid provided by CV, converts it into ROS row-major convention, applies obstacle 
-inflation, and republishes a world-aligned occupancy grid suitable for planning.
+This package consumes the occupancy grid provided by CV, converts it into ROS row-major convention, adds a border on
+the far edges, applies obstacle inflation, and republishes the occupancy grid suitable for planning. The
+grid origin is transformed from the incoming frame to the configured output frame using TF2.
 
 ### Grid conventions
 The occupancy grid from CV is expected to have the following conventions
 - Column major
 - Height = number of cells in +x direction, width = number of cells in +y direction
 - Top left is origin
-- Is centered around the robot in the y axis, and starts `robot_forward_offset_m` meters in front of the robot
+- Origin is set by the publisher (e.g. CV pipeline) in its frame
 
 The occupancy grid transformed by the node has the standard ROS2 convention, where
 - Row major
@@ -43,7 +44,6 @@ The grid is indexed with (y, x) in 2d, and (y * width + x) in 1d.
 
 ### Subscribed Topics
 - occupancy_grid (`nav_msgs/msg/OccupancyGrid`) - Input occupancy grid
-- odom (`nav_msgs/msg/Odometry`) - Robot odometry, used to orient and place the grid in the world frame
 
 ### Published Topics
-- occupancy_grid_transform (`nav_msgs/msg/OccupancyGrid`) - Transformed and inflated occupancy grid
+- transformed_occupancy_grid (`nav_msgs/msg/OccupancyGrid`) - Bordered and inflated occupancy grid

--- a/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform.py
+++ b/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform.py
@@ -1,13 +1,12 @@
 import nav_utils.config
 import numpy as np
 import rclpy
+import tf2_geometry_msgs  # noqa: F401 — registers PoseStamped transform handlers
 from geometry_msgs.msg import PoseStamped
 from nav_msgs.msg import MapMetaData, OccupancyGrid
 from rclpy.node import Node
 from std_msgs.msg import Header
 from tf2_ros import Buffer, TransformListener
-
-import tf2_geometry_msgs  # noqa: F401 — registers PoseStamped transform handlers
 
 from .occupancy_grid_transform_impl import add_border, cv_occupancy_grid_to_ros_grid, inflate_grid
 from .occupancy_grid_trasform_config import OccupancyGridTransformConfig

--- a/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform.py
+++ b/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform.py
@@ -1,11 +1,15 @@
 import nav_utils.config
 import numpy as np
 import rclpy
-from nav_msgs.msg import MapMetaData, OccupancyGrid, Odometry
+from geometry_msgs.msg import PoseStamped
+from nav_msgs.msg import MapMetaData, OccupancyGrid
 from rclpy.node import Node
 from std_msgs.msg import Header
+from tf2_ros import Buffer, TransformListener
 
-from .occupancy_grid_transform_impl import compute_origin_pose, cv_occupancy_grid_to_ros_grid, inflate_grid
+import tf2_geometry_msgs  # noqa: F401 — registers PoseStamped transform handlers
+
+from .occupancy_grid_transform_impl import add_border, cv_occupancy_grid_to_ros_grid, inflate_grid
 from .occupancy_grid_trasform_config import OccupancyGridTransformConfig
 
 
@@ -15,31 +19,30 @@ class OccupancyGridTransform(Node):
 
         self.config: OccupancyGridTransformConfig = nav_utils.config.load(self, OccupancyGridTransformConfig)
 
-        self._odom: Odometry | None = None
+        self.tf_buffer = Buffer()
+        self.tf_listener = TransformListener(self.tf_buffer, self)
 
         self.create_subscription(OccupancyGrid, "occupancy_grid", self.occupancy_grid_callback, 10)
-        self.create_subscription(Odometry, "odom", self.odom_callback, 10)
 
-        self.publisher = self.create_publisher(OccupancyGrid, "occupancy_grid_transform", 10)
-
-    def odom_callback(self, msg: Odometry) -> None:
-        self._odom = msg
+        self.publisher = self.create_publisher(OccupancyGrid, "transformed_occupancy_grid", 10)
 
     def occupancy_grid_callback(self, msg: OccupancyGrid) -> None:
+        try:
+            origin_raw = PoseStamped(header=Header(frame_id=msg.header.frame_id), pose=msg.info.origin)
+            origin_transformed = self.tf_buffer.transform(origin_raw, self.config.frame_id).pose
+        except Exception as e:
+            self.get_logger().error(f"TF {msg.header.frame_id}->{self.config.frame_id} unavailable, skipping: {e}")
+            return
+
         grid = cv_occupancy_grid_to_ros_grid(msg)
-        inflated_grid = inflate_grid(grid, self.config.inflation_params)
+        bordered_grid = add_border(grid)
+        inflated_grid = inflate_grid(bordered_grid, self.config.inflation_params)
         height, width = grid.shape
-        origin = compute_origin_pose(
-            odom=self._odom.pose.pose if self._odom is not None else None,
-            robot_forward_offset_m=self.config.robot_forward_offset_m,
-            grid_height_cells=height,
-            resolution=msg.info.resolution,
-        )
 
         self.publisher.publish(
             OccupancyGrid(
-                header=Header(frame_id=self.config.grid_frame_id),
-                info=MapMetaData(resolution=msg.info.resolution, width=width, height=height, origin=origin),
+                header=Header(frame_id=self.config.frame_id),
+                info=MapMetaData(resolution=msg.info.resolution, width=width, height=height, origin=origin_transformed),
                 data=inflated_grid.astype(np.int8).reshape(-1).tolist(),
             )
         )

--- a/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform_impl.py
+++ b/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform_impl.py
@@ -4,9 +4,7 @@ import math
 from itertools import product
 
 import numpy as np
-from geometry_msgs.msg import Point, Pose, Quaternion
 from nav_msgs.msg import OccupancyGrid
-from nav_utils.geometry import get_yaw_radians_from_quaternion, rotate_by_yaw
 
 from .occupancy_grid_trasform_config import InflationParams
 
@@ -61,6 +59,26 @@ def cv_occupancy_grid_to_ros_grid(grid: OccupancyGrid) -> np.ndarray:
     return np.flipud(grid)
 
 
+def add_border(grid: np.ndarray) -> np.ndarray:
+    """
+    Add a 1-cell occupied border on all edges except the bottom (closest to robot).
+
+    Sets the top row, left column, and right column to 100 (occupied). The bottom row (y=0) is
+    left untouched since it is nearest to the robot. When followed by `inflate_grid`, the border
+    produces a soft falloff that discourages planning near grid edges.
+
+    Args:
+        grid: 2D occupancy grid of shape `(height, width)`.
+
+    Returns:
+        The same grid array, modified in place.
+    """
+    grid[-1, :] = 100  # top row
+    grid[:, 0] = 100  # left column
+    grid[:, -1] = 100  # right column
+    return grid
+
+
 def inflate_grid(grid: np.ndarray, params: InflationParams) -> np.ndarray:
     """
     Inflate obstacles in a 2D occupancy grid.
@@ -101,39 +119,3 @@ def inflate_grid(grid: np.ndarray, params: InflationParams) -> np.ndarray:
 
     return output.astype(np.int8)
 
-
-def compute_origin_pose(
-    odom: Pose | None, robot_forward_offset_m: float, grid_height_cells: int, resolution: float
-) -> Pose:
-    """
-    Compute the published OccupancyGrid origin pose.
-
-    The returned pose corresponds to `OccupancyGrid.info.origin`: the world pose of the grid's (0, 0) cell (i.e., the
-    grid's lower-left corner in the grid's own coordinate system).
-
-    This transform assumes the grid is:
-    - shifted `robot_forward_offset_m` meters forward of the robot along +x
-    - centered laterally on the robot, so the origin is `height/2` cells to the right (negative y) of the robot
-
-    Args:
-        odom: Robot pose in the target frame. If None, the origin is assumed to be (0, 0, 0).
-        robot_forward_offset_m: Forward distance (meters) from the robot to the grid origin along +x.
-        grid_height_cells: Grid height (cells), used to center the grid about the robot in y.
-        resolution: Cell size (meters/cell).
-
-    Returns:
-        A `geometry_msgs/msg/Pose` suitable for `OccupancyGrid.info.origin`.
-    """
-
-    local = Point(x=robot_forward_offset_m, y=-grid_height_cells * resolution / 2.0, z=0.0)
-
-    if odom is not None:
-        yaw = get_yaw_radians_from_quaternion(odom.orientation)
-        rotated = rotate_by_yaw(local, yaw)
-
-        return Pose(
-            position=Point(x=odom.position.x + rotated.x, y=odom.position.y + rotated.y, z=0.0),
-            orientation=odom.orientation,
-        )
-    else:
-        return Pose(position=Point(x=local.x, y=local.y, z=0.0), orientation=Quaternion(w=1.0, x=0.0, y=0.0, z=0.0))

--- a/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform_impl.py
+++ b/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform_impl.py
@@ -74,7 +74,7 @@ def add_border(grid: np.ndarray) -> np.ndarray:
         The same grid array, modified in place.
     """
     grid[-1, :] = 100  # top row
-    grid[:, 0] = 100  # left column
+    grid[0, :] = 100  # bottom row
     grid[:, -1] = 100  # right column
     return grid
 

--- a/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform_impl.py
+++ b/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform_impl.py
@@ -118,4 +118,3 @@ def inflate_grid(grid: np.ndarray, params: InflationParams) -> np.ndarray:
         inflate(x, y)
 
     return output.astype(np.int8)
-

--- a/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_trasform_config.py
+++ b/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_trasform_config.py
@@ -67,4 +67,3 @@ class OccupancyGridTransformConfig:
     this frame.
     """
     frame_id: str = "odom"
-

--- a/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_trasform_config.py
+++ b/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_trasform_config.py
@@ -66,11 +66,5 @@ class OccupancyGridTransformConfig:
     All grid coordinates and the computed origin pose are expressed in
     this frame.
     """
-    grid_frame_id: str = "odom"
+    frame_id: str = "odom"
 
-    """Forward offset (in meters) from the robot to the near edge of the grid.
-
-    Used when computing the grid origin. The grid is assumed to be centered laterally on the robot (+y) and to begin 
-    `robot_forward_offset_m` meters in front of the robot along +x.
-    """
-    robot_forward_offset_m: float = 0.60

--- a/occupancy_grid_transform/package.xml
+++ b/occupancy_grid_transform/package.xml
@@ -13,6 +13,9 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>nav_utils</exec_depend>
+  <exec_depend>tf2_ros</exec_depend>
+  <exec_depend>tf2_ros_py</exec_depend>
+  <exec_depend>tf2_geometry_msgs</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>

--- a/occupancy_grid_transform/test/test_occupancy_grid_transform_impl.py
+++ b/occupancy_grid_transform/test/test_occupancy_grid_transform_impl.py
@@ -78,4 +78,3 @@ def test_inflate_grid():
     # outside r_soft
     assert out[3, 6] == 0
     assert out[0, 3] == 0
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ module = [
 
     "tf2_ros.*",
     "tf_transformations.*",
+    "tf2_geometry_msgs.*",
+    "tf2_geometry_msgs",
 ]
 ignore_missing_imports = true
 disable_error_code = ["attr-defined"]

--- a/scripts/checks.sh
+++ b/scripts/checks.sh
@@ -111,7 +111,7 @@ ruff format --check "${PKG_DIRS[@]}"
 echo "==> Ruff lint"
 ruff check "${PKG_DIRS[@]}"
 
-MYPYPATH="$(printf "%s:" "${PKG_DIRS[@]}")"
+MYPYPATH="$(printf "%s:" "${ALL_PKG_DIRS[@]}")"
 export MYPYPATH="${MYPYPATH%:}"
 
 echo "==> mypy (${#PKG_DIRS[@]} packages)"


### PR DESCRIPTION
## What has changed                                                                                                 
- Use TF2 instead of manual calculation to compute the occupancy grid origin transform
- Add an inflated border around the occupancy grid to avoid driving too close to the border

## Testing plan
Wrote and passed unit tests:
```
============================== 3 passed in 0.08s ===============================
Finished <<< occupancy_grid_transform [0.36s]
```