### PR TITLE
Speed up ROS2 test CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Build CI image
 
 on:
   push:
-    branches: [main]
+    branches: [main, ryanliao/ci-speedup]
     paths:
       - Dockerfile
       - '**/package.xml'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,7 @@ name: Build CI image
 
 on:
   push:
-    branches: [main, ryanliao/ci-speedup]
+    branches: [main]
     paths:
       - Dockerfile
       - '**/package.xml'

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,4 +32,6 @@ jobs:
         with:
           context: .
           push: true
-          tags: ghcr.io/umigv/nav_infrastructure_simple:latest
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,35 @@
+name: Build CI image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - Dockerfile
+      - '**/package.xml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/umigv/nav_infrastructure_simple:latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,10 +25,13 @@ jobs:
           submodules: recursive
 
       - name: rosdep update
-        run: rosdep update
+        run: |
+          apt-get update
+          rosdep update
 
       - name: Install ROS deps via rosdep
         run: |
+          apt-get install -y python3-pip
           rosdep install --from-paths ws/src/nav_infrastructure_simple --ignore-src -r -y
 
       - name: Build (repo packages)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   ros-tests:
     runs-on: ubuntu-22.04
+    container: ros:humble
     env:
       ROS_DISTRO: humble
 
@@ -23,15 +24,8 @@ jobs:
           path: ws/src/nav_infrastructure_simple
           submodules: recursive
 
-      - name: Set up ROS
-        uses: ros-tooling/setup-ros@v0.7
-        with:
-          required-ros-distributions: ${{ env.ROS_DISTRO }}
-
-      - name: rosdep init/update
-        run: |
-          sudo rosdep init 2>/dev/null || true
-          rosdep update
+      - name: rosdep update
+        run: rosdep update
 
       - name: Install ROS deps via rosdep
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,11 @@ concurrency:
 jobs:
   ros-tests:
     runs-on: ubuntu-22.04
-    container: ros:humble
+    container:
+      image: ghcr.io/umigv/nav_infrastructure_simple:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     env:
       ROS_DISTRO: humble
 
@@ -24,15 +28,8 @@ jobs:
           path: ws/src/nav_infrastructure_simple
           submodules: recursive
 
-      - name: rosdep update
-        run: |
-          apt-get update
-          rosdep update
-
-      - name: Install ROS deps via rosdep
-        run: |
-          apt-get install -y python3-pip
-          rosdep install --from-paths ws/src/nav_infrastructure_simple --ignore-src -r -y
+      - name: Install any new deps (top-up)
+        run: rosdep install --from-paths ws/src/nav_infrastructure_simple --ignore-src -r -y
 
       - name: Build (repo packages)
         working-directory: ws/src/nav_infrastructure_simple

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: ci
+name: test
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: test-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: ws/src/nav_infrastructure_simple
-          submodules: recursive
 
       - name: Install any new deps (top-up)
         run: rosdep install --from-paths ws/src/nav_infrastructure_simple --ignore-src -r -y

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: test
 
+permissions:
+  contents: read
+  packages: read
+
 on:
   push:
     branches: [main]
@@ -14,31 +18,29 @@ jobs:
   ros-tests:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/umigv/nav_infrastructure_simple:latest
+      image: ghcr.io/${{ github.repository }}:latest
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-    env:
-      ROS_DISTRO: humble
+
+    defaults:
+      run:
+        working-directory: ws/src/${{ github.event.repository.name }}
 
     steps:
-      - name: Checkout (into ws/src/nav_infrastructure_simple)
+      - name: Checkout into repo
         uses: actions/checkout@v4
         with:
-          path: ws/src/nav_infrastructure_simple
+          path: ws/src/${{ github.event.repository.name }}
 
       - name: Install any new deps (top-up)
-        run: rosdep install --from-paths ws/src/nav_infrastructure_simple --ignore-src -r -y
+        run: rosdep install --from-paths . --ignore-src -r -y
 
       - name: Build (repo packages)
-        working-directory: ws/src/nav_infrastructure_simple
-        run: |
-          bash scripts/build.sh
+        run: bash scripts/build.sh
 
       - name: Test (repo packages)
-        working-directory: ws/src/nav_infrastructure_simple
-        run: |
-          bash scripts/test.sh
+        run: bash scripts/test.sh
 
       - name: Upload logs on failure
         if: failure()

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,4 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* /tmp/src
 
 WORKDIR /
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ros:humble
+
+WORKDIR /tmp/src/nav_infrastructure_simple
+COPY . .
+
+RUN apt-get update \
+ && apt-get install -y python3-pip \
+ && rosdep update \
+ && rosdep install --from-paths /tmp/src/nav_infrastructure_simple --ignore-src -r -y \
+ && rm -rf /var/lib/apt/lists/* /tmp/src
+
+WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ros:humble
 
+ENV ROS_HOME=/opt/ros_home
+
 WORKDIR /tmp/src/nav_infrastructure_simple
 COPY . .
 


### PR DESCRIPTION
## What has changed
- Added Dockerfile and a docker build workflow to push and build docker image on pushes for ROS2 test to use so the CI doesn't have to do any setup or install any dependency 
- `.github/workflows/test.yml` uses the custom image instead. Removes submodule initialization since they shouldn't be tested

## Testing plan
### Benchmarking
The original CI took around 5 minutes to run:
<img width="2757" height="624" alt="Screenshot_from_2026-02-20_01-34-34" src="https://github.com/user-attachments/assets/77489497-172a-402b-ac47-5cb458003ced" />
As shown below, the test CI now takes around 40 seconds, which is an 86% reduction. 

The docker build script runs correctly as shown in the actions log
<img width="571" height="127" alt="Screenshot from 2026-02-20 02-43-29" src="https://github.com/user-attachments/assets/3c94d229-5d40-4fe9-9c09-1d776886fe4b" />
