### PR TITLE
Fix required parameter deprecation bug in config loader

### DIFF
--- a/nav_utils/test/test_config.py
+++ b/nav_utils/test/test_config.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 
 import pytest
 from nav_utils.config import load
+from rcl_interfaces.msg import ParameterDescriptor
 
 
 class Param:
@@ -17,7 +18,7 @@ class MockNode:
     def get_name(self) -> str:
         return "MockNode"
 
-    def declare_parameter(self, key: str, default_value=None):
+    def declare_parameter(self, key: str, default_value=None, descriptor: ParameterDescriptor | None = None):
         self.declared.append((key, default_value))
         if key not in self._store:
             self._store[key] = default_value


### PR DESCRIPTION
## What has changed
ROS2 no longer allows us to declare a parameter without a type. This fixes the issue for required parameters (optional parameters have type inferred through the optional value)

## Testing plan
Tested with a node with required parameters. `ros2 param dump` was able to get the correct value
Unit tests updated to include the interface change