### PR TITLE
Don't purge apt cache in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
  && apt-get install -y python3-pip \
  && rosdep update \
  && rosdep install --from-paths /tmp/src/nav_infrastructure_simple --ignore-src -r -y \
- && rm -rf /var/lib/apt/lists/* /tmp/src
+ && rm -rf /tmp/src
 
 WORKDIR /
 


### PR DESCRIPTION
## What has changed
Remove purging the apt cache in Dockerfile. There is a bug where new packages in the docker image can't be installed by apt since the cache is gone, resulting in the workflow failing.