### PR TITLE
Set correct device name for teleop.launch.py

### DIFF
--- a/nav_bringup/config/teleop_ps4.yaml
+++ b/nav_bringup/config/teleop_ps4.yaml
@@ -1,5 +1,6 @@
 joy:
   ros__parameters:
+    device_name: "Sony Interactive Entertainment Wireless Controller"
     deadzone: 0.05
     autorepeat_rate: 20.0
 

--- a/nav_bringup/config/teleop_xbox.yaml
+++ b/nav_bringup/config/teleop_xbox.yaml
@@ -1,5 +1,6 @@
 joy:
   ros__parameters:
+    device_name: "Xbox One Elite 2 Controller"
     deadzone: 0.05
     autorepeat_rate: 20.0
 

--- a/nav_bringup/launch/teleop.launch.py
+++ b/nav_bringup/launch/teleop.launch.py
@@ -11,7 +11,6 @@ CONTROLLERS = ("ps4", "xbox")
 def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
     bringup_share = get_package_share_directory("nav_bringup")
     controller = LaunchConfiguration("controller").perform(context).strip().lower()
-    joystick_dev = LaunchConfiguration("joystick_dev").perform(context).strip()
     teleop_params = PathJoinSubstitution([bringup_share, "config", f"teleop_{controller}.yaml"])
 
     return [
@@ -22,7 +21,6 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
             output="screen",
             parameters=[
                 teleop_params,
-                {"dev": joystick_dev},
             ],
         ),
         Node(
@@ -48,11 +46,6 @@ def generate_launch_description() -> LaunchDescription:
                 "controller",
                 choices=list(CONTROLLERS),
                 description="Controller profile",
-            ),
-            DeclareLaunchArgument(
-                "joystick_dev",
-                default_value="/dev/input/js0",
-                description="Device of joystick",
             ),
             OpaqueFunction(function=launch_setup),
         ]


### PR DESCRIPTION
## What has changed
`teleop.lauch.py` currently uses a `dev` parameter to set the device for joystick. Joy node actually doesn't take a device path but instead take by device name / id. This means our current config is useless and doesn't actually select the right controller if multiple are available. This fixes the problem by setting the correct device name in the config file of each controller.

## Testing plan
Tested in simulation with multiple joystick input devices. The correct controller is selected