### PR TITLE
Add missing deps in environment setup script for utm vm

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -42,6 +42,7 @@ python3 -m pip install -U pip
 python3 -m pip install -e "$REPO_ROOT[tooling]"
 
 log "Installing ROS deps via rosdep"
+rosdep update
 rosdep install --from-paths "$REPO_ROOT" --ignore-src -r -y
 
 log "Adding $USER to dialout group (USB/serial device access)"


### PR DESCRIPTION
Closes #73 

## What has changed
Add rosdep update on setup to ensure the rosdep is up to date. The VM setup script is missing python / pip3 and rosdep init, but that is to be added in nav-environment

## Testing plan
Tested on fresh VM