### PR TITLE
Rename nav_infrastructure_simple reference in repo to nav_stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,13 @@ FROM ros:humble
 
 ENV ROS_HOME=/opt/ros_home
 
-WORKDIR /tmp/src/nav_infrastructure_simple
+WORKDIR /tmp/src/nav_stack
 COPY . .
 
 RUN apt-get update \
  && apt-get install -y python3-pip \
  && rosdep update \
- && rosdep install --from-paths /tmp/src/nav_infrastructure_simple --ignore-src -r -y \
+ && rosdep install --from-paths /tmp/src/nav_stack --ignore-src -r -y \
  && rm -rf /tmp/src
 
 WORKDIR /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "nav-infrastructure-tooling"
+name = "nav-stack-tooling"
 version = "0.1.0"
 description = "Tooling config for a ROS 2 Python workspace"
 requires-python = ">=3.10"


### PR DESCRIPTION
Closes #76 

## What has changed
Changed all mentions of nav_infrastructure_simple to nav_stack since we are renaming the repo