### PR TITLE
Clean up config, add support for lists and path as param

### DIFF
--- a/nav_utils/README.md
+++ b/nav_utils/README.md
@@ -9,10 +9,15 @@ parameter key. The field’s default value (if provided) is used as the paramete
 
 Mapping rules:
 - Each dataclass field name corresponds to a ROS 2 parameter key.
-- If the field has a default value (or default_factory), the parameter is optional and the default is used when the key 
+- If the field has a default value (or default_factory), the parameter is optional and the default is used when the key
 is not supplied in YAML.
 - If the field has no default, the parameter is required; `load()` will raise if it is missing / unset.
 - Nested dataclasses are supported and map to nested parameter dictionaries.
+
+Supported field types:
+- Primitives: `bool`, `int`, `float`, `str`, `bytes`
+- Arrays: `list[bool]`, `list[int]`, `list[float]`, `list[str]`
+- `pathlib.Path` (declared as a string parameter, coerced to `Path` on load)
 
 For example, you can create the following config dataclass:
 ```py
@@ -20,14 +25,14 @@ from dataclasses import dataclass, field
 
 @dataclass
 class Weights:
-    heading: float = 1.0
     clearance: float
+    heading: float = 1.0
 
 @dataclass
 class PlannerConfig:
-    max_iters: int = 10_000
-    timeout_s: float
     weights: Weights
+    timeout_s: float
+    max_iters: int = 10_000
 ```
 
 Which would map to a ROS2 config yaml structure like this:

--- a/nav_utils/nav_utils/config.py
+++ b/nav_utils/nav_utils/config.py
@@ -3,16 +3,19 @@ nav_utils.config
 
 Dataclass-backed ROS 2 parameter loading.
 
-`load(node, cls, prefix="")` constructs a dataclass instance by reading ROS 2 parameters
-from `node`.
+`load(node, cls)` constructs a dataclass instance by reading ROS 2 parameters from `node`.
 
 Mapping rules:
 - Each dataclass field name corresponds to a ROS 2 parameter key.
 - If the field has a default value (or default_factory), the parameter is optional and
   the default is used when the key is not supplied in YAML.
-- If the field has no default, the parameter is required; `load()` will raise if it
-  is missing / unset.
+- If the field has no default, the parameter is required; `load()` will raise if it is missing / unset.
 - Nested dataclasses are supported and map to nested parameter dictionaries.
+
+Supported field types:
+- Primitives: `bool`, `int`, `float`, `str`, `bytes`
+- Arrays: `list[bool]`, `list[int]`, `list[float]`, `list[str]`
+- `pathlib.Path` (declared as a string parameter, coerced to `Path` on load)
 
 For example, you can create the following config dataclass:
 ```py
@@ -22,14 +25,14 @@ import nav_utils.config
 
 @dataclass
 class Weights:
-    heading: float = 1.0
     clearance: float  # required
+    heading: float = 1.0
 
 @dataclass
 class PlannerConfig:
-    max_iters: int = 10_000
-    timeout_s: float = 0.2
     weights: Weights
+    timeout_s: float       # required
+    max_iters: int = 10_000
 ```
 
 Which would map to a ROS2 config yaml structure like this:
@@ -58,32 +61,51 @@ class Planner(Node):
 
 import sys
 from collections.abc import Callable
-from dataclasses import MISSING, fields, is_dataclass
-from typing import Any, TypeVar, cast, get_type_hints
+from dataclasses import MISSING, dataclass, fields, is_dataclass
+from pathlib import Path
+from typing import Any, Generic, TypeVar, cast, get_type_hints
 
 from rcl_interfaces.msg import ParameterDescriptor
 from rclpy.node import Node
 from rclpy.parameter import Parameter
 
 T = TypeVar("T")
+RawT = TypeVar("RawT")
+FieldT = TypeVar("FieldT")
 
-_TYPE_MAP: dict[type, Parameter.Type] = {
-    bool: Parameter.Type.BOOL,
-    int: Parameter.Type.INTEGER,
-    float: Parameter.Type.DOUBLE,
-    str: Parameter.Type.STRING,
+
+def _identity(x: T) -> T:
+    return x
+
+
+@dataclass
+class _Entry(Generic[RawT, FieldT]):
+    raw_type: type[RawT]
+    ros_type: Parameter.Type
+    deserialize: Callable[[RawT], FieldT]  # raw -> field (after reading from ROS)
+    serialize: Callable[[FieldT], RawT]  # field -> raw (when declaring with a default)
+
+
+_ENTRIES: dict[type, _Entry[Any, Any]] = {
+    bool: _Entry(bool, Parameter.Type.BOOL, _identity, _identity),
+    int: _Entry(int, Parameter.Type.INTEGER, _identity, _identity),
+    float: _Entry(float, Parameter.Type.DOUBLE, _identity, _identity),
+    str: _Entry(str, Parameter.Type.STRING, _identity, _identity),
+    bytes: _Entry(bytes, Parameter.Type.BYTE_ARRAY, _identity, _identity),
+    list[bool]: _Entry(list[bool], Parameter.Type.BOOL_ARRAY, _identity, _identity),
+    list[int]: _Entry(list[int], Parameter.Type.INTEGER_ARRAY, _identity, _identity),
+    list[float]: _Entry(list[float], Parameter.Type.DOUBLE_ARRAY, _identity, _identity),
+    list[str]: _Entry(list[str], Parameter.Type.STRING_ARRAY, _identity, _identity),
+    Path: _Entry(str, Parameter.Type.STRING, Path, str),
 }
 
 
-# This is vibe coded
-def load(node: Node, cls: type[T], prefix: str = "") -> T:
+def load(node: Node, cls: type[T], _prefix: str = "") -> T:
     """
     Load ROS 2 parameters from `node` into a dataclass instance of type `cls`.
     Args:
         node: ROS 2 node providing parameters.
         cls: Dataclass type to construct.
-        prefix: Optional prefix for parameter keys. If non-empty, keys become
-            f"{prefix}{field_name}". (Callers typically pass "planner." or similar.)
     Returns:
         An instance of `cls` populated from ROS 2 parameters.
     Raises:
@@ -91,7 +113,7 @@ def load(node: Node, cls: type[T], prefix: str = "") -> T:
     """
     if not is_dataclass(cls):
         raise TypeError(f"{cls!r} is not a dataclass type")
-    kwargs: dict[str, Any] = {}
+
     try:
         frame = sys._getframe(1)
         type_hints = get_type_hints(cls, globalns=frame.f_globals, localns=frame.f_locals)
@@ -100,34 +122,43 @@ def load(node: Node, cls: type[T], prefix: str = "") -> T:
             type_hints = get_type_hints(cls)
         except Exception:
             type_hints = {}
+
+    kwargs: dict[str, Any] = {}
+
     for f in fields(cls):
-        key = f"{prefix}{f.name}" if prefix else f.name
+        key = f"{_prefix}{f.name}"
         field_type = type_hints.get(f.name, f.type)
         try:
-            is_nested_dataclass = is_dataclass(field_type)
+            if is_dataclass(field_type):
+                kwargs[f.name] = load(node, cast(type, field_type), _prefix=f"{key}.")
+                continue
         except (TypeError, AttributeError):
-            is_nested_dataclass = False
-        if is_nested_dataclass:
-            kwargs[f.name] = load(node, field_type, prefix=f"{key}.")
-            continue
-        has_default = f.default is not MISSING
-        has_factory = f.default_factory is not MISSING
+            pass
 
-        if not has_default and not has_factory:
-            param_type = _TYPE_MAP.get(field_type)
-            if param_type is None:
-                raise TypeError(
-                    f"Parameter '{key}' has unsupported type {field_type!r}. "
-                    f"Supported types: {', '.join(t.__name__ for t in _TYPE_MAP)}"
-                )
-            node.declare_parameter(key, descriptor=ParameterDescriptor(type=param_type.value))
+        entry = _ENTRIES.get(field_type)
+
+        if entry is None:
+            raise TypeError(
+                f"Parameter '{key}' has unsupported type {field_type!r}. "
+                f"Supported types: {', '.join(t.__name__ for t in _ENTRIES)}"
+            )
+
+        # fmt: off
+        default_value = (
+            f.default if f.default is not MISSING
+            else f.default_factory() if f.default_factory is not MISSING
+            else MISSING
+        )
+        # fmt: on
+
+        if default_value is MISSING:
+            node.declare_parameter(key, descriptor=ParameterDescriptor(type=entry.ros_type.value))
             value = node.get_parameter(key).value
             if value is None:
                 raise RuntimeError(f"Required parameter '{key}' not set for node '{node.get_name()}'")
-            kwargs[f.name] = value
+            kwargs[f.name] = entry.deserialize(value)
         else:
-            default_value = f.default if has_default else cast(Callable[[], Any], f.default_factory)()
-            node.declare_parameter(key, default_value)
-            kwargs[f.name] = node.get_parameter(key).value
+            node.declare_parameter(key, entry.serialize(default_value))
+            kwargs[f.name] = entry.deserialize(node.get_parameter(key).value)
 
     return cls(**kwargs)

--- a/nav_utils/test/test_config.py
+++ b/nav_utils/test/test_config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import pytest
 from nav_utils.config import load
@@ -107,3 +108,70 @@ def test_load_nested_dataclass():
     assert config.rate == 42
     assert config.inner.gain == 1.25
     assert config.inner.name == "abc"
+
+
+def test_load_bytes():
+    @dataclass
+    class Config:
+        data: bytes
+
+    node = MockNode(initial={"data": b"\x01\x02\x03"})
+    config = load(node, Config)
+
+    assert config.data == b"\x01\x02\x03"
+
+
+def test_load_list():
+    @dataclass
+    class Config:
+        ids: list[int]
+
+    node = MockNode(initial={"ids": [10, 20, 30]})
+    config = load(node, Config)
+
+    assert config.ids == [10, 20, 30]
+
+
+def test_load_path_required():
+    @dataclass
+    class Config:
+        log_dir: Path
+
+    node = MockNode(initial={"log_dir": "/tmp/logs"})
+    config = load(node, Config)
+
+    assert config.log_dir == Path("/tmp/logs")
+    assert isinstance(config.log_dir, Path)
+
+
+def test_load_path_default():
+    @dataclass
+    class Config:
+        log_dir: Path = Path("/var/log")
+
+    node = MockNode(initial={})
+    config = load(node, Config)
+
+    assert config.log_dir == Path("/var/log")
+    assert isinstance(config.log_dir, Path)
+
+
+def test_load_path_default_overridden():
+    @dataclass
+    class Config:
+        log_dir: Path = Path("/var/log")
+
+    node = MockNode(initial={"log_dir": "/tmp/override"})
+    config = load(node, Config)
+
+    assert config.log_dir == Path("/tmp/override")
+
+
+def test_load_unsupported_type_raises():
+    @dataclass
+    class Config:
+        value: tuple
+
+    node = MockNode(initial={})
+    with pytest.raises(TypeError, match=r"unsupported type"):
+        load(node, Config)


### PR DESCRIPTION
## What has changed
1. Add support for lists of native types for param. This is natively supported by ROS2
2. Add support for `pathlib.Path` as param you input a string in yaml and it will be coerced into a path. More generically we can define custom conversions in the future as long as we provide a way to convert to / from a ROS2 param type.

## Testing plan
Unit tests still pass