### PR TITLE
Occupancy grid package fixes

### DIFF
--- a/nav_bringup/README.md
+++ b/nav_bringup/README.md
@@ -76,7 +76,7 @@ ros2 launch nav_bringup sensors.launch.py [simulation:=true]
 - `enc_vel/raw` (`geometry_msgs/TwistWithCovarianceStamped`) - Simulated encoder velocity with noise and OU drift
 - `odom/ground_truth` (`nav_msgs/Odometry`) - Noiseless true pose in `map` frame
 (`child_frame_id = base_link_ground_truth`)
-- `occ_grid` (`nav_msgs/OccupancyGrid`) - Robot-centric occupancy grid from static obstacle map
+- `occupancy_grid/raw` (`nav_msgs/OccupancyGrid`) - Robot-centric occupancy grid from static obstacle map
 - `occupancy_grid/ground_truth` (`nav_msgs/OccupancyGrid`) - Full static obstacle map (latched)
 
 ### Broadcasted TF Frames

--- a/nav_bringup/launch/navigation.launch.py
+++ b/nav_bringup/launch/navigation.launch.py
@@ -22,7 +22,7 @@ def generate_launch_description() -> LaunchDescription:
                     {"frame_id": frames["odom_frame"]},
                 ],
                 remappings=[
-                    ("occupancy_grid", "occ_grid"),
+                    ("occupancy_grid", "occupancy_grid/raw"),
                     ("transformed_occupancy_grid", "inflated_occupancy_grid"),
                 ],
             ),

--- a/nav_bringup/launch/sensors.launch.py
+++ b/nav_bringup/launch/sensors.launch.py
@@ -93,12 +93,13 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
                 {
                     "map_file_path": map_file,
                     "map_frame_id": frames["map_frame"],
+                    "base_frame_id": frames["base_frame"],
                     "ground_truth_base_frame_id": frames["ground_truth_base_frame"],
                 }
             ],
             remappings=[
                 ("odom", "odom/ground_truth"),
-                ("occupancy_grid", "occ_grid"),
+                ("occupancy_grid", "occupancy_grid/raw"),
                 ("occupancy_grid/ground_truth", "occupancy_grid/ground_truth"),
             ],
         ),

--- a/occupancy_grid_simulator/README.md
+++ b/occupancy_grid_simulator/README.md
@@ -18,7 +18,7 @@ The map file is a JSON file with the following structure:
 - `odom` (`nav_msgs/Odometry`) - Robot pose in the map frame
 
 ## Published Topics
-- `occupancy_grid` (`nav_msgs/OccupancyGrid`) - Robot-centric occupancy grid in `base_link` frame, published 
+- `occupancy_grid` (`nav_msgs/OccupancyGrid`) - Robot-centric occupancy grid stamped in `base_frame_id`, published 
 periodically
 - `occupancy_grid/ground_truth` (`nav_msgs/OccupancyGrid`) - Full static obstacle map in `map` frame
 
@@ -53,5 +53,6 @@ forward so the grid extends mostly in front of the robot).
 | `offset_x_m` | `float` | `0.0` | X offset of the grid origin from the robot (m) |
 | `offset_y_m` | `float` | `-2.5` | Y offset of the grid origin from the robot (m) |
 | `map_frame_id` | `str` | `map` | TF frame ID for the map frame |
-| `ground_truth_base_frame_id` | `str` | `base_link_ground_truth` | TF frame ID for the true robot pose. The grid is generated and published in this frame. |
+| `base_frame_id` | `str` | `base_link` | TF frame ID stamped on the published occupancy grid, matching what a real perception stack would use |
+| `ground_truth_base_frame_id` | `str` | `base_link_ground_truth` | TF frame ID for the true robot pose, used to generate grid cell positions |
 | `publish_period_s` | `float` | `0.03` | Publish period for the robot-centric occupancy grid (s) |

--- a/occupancy_grid_simulator/occupancy_grid_simulator/occupancy_grid_simulator.py
+++ b/occupancy_grid_simulator/occupancy_grid_simulator/occupancy_grid_simulator.py
@@ -117,7 +117,7 @@ class OccupancyGridSimulator(Node):
 
         self.occupancy_grid_publisher.publish(
             OccupancyGrid(
-                header=Header(stamp=self.get_clock().now().to_msg(), frame_id=self.config.ground_truth_base_frame_id),
+                header=Header(stamp=self.get_clock().now().to_msg(), frame_id=self.config.base_frame_id),
                 info=MapMetaData(
                     resolution=self.resolution_m,
                     width=self.width_cells,

--- a/occupancy_grid_simulator/occupancy_grid_simulator/occupancy_grid_simulator_config.py
+++ b/occupancy_grid_simulator/occupancy_grid_simulator/occupancy_grid_simulator_config.py
@@ -10,5 +10,6 @@ class OccupancyGridSimulatorConfig:
     offset_x_m: float = 0.0
     offset_y_m: float = -2.5
     map_frame_id: str = "map"
+    base_frame_id: str = "base_link"
     ground_truth_base_frame_id: str = "base_link_ground_truth"
     publish_period_s: float = 0.03

--- a/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform_impl.py
+++ b/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform_impl.py
@@ -1,5 +1,4 @@
-import math
-from itertools import product
+from functools import lru_cache
 
 import numpy as np
 
@@ -26,6 +25,19 @@ def add_border(grid: np.ndarray) -> np.ndarray:
     return grid
 
 
+@lru_cache(maxsize=1)
+def _make_inflation_kernel(r_hard: int, r_soft: int, decay: float) -> np.ndarray:
+    """Precompute a (2*r_soft+1) x (2*r_soft+1) kernel of inflation values."""
+    ys, xs = np.mgrid[-r_soft : r_soft + 1, -r_soft : r_soft + 1]
+    dists = np.hypot(xs, ys)
+    kernel = np.where(
+        dists <= r_hard,
+        100,
+        np.where(dists <= r_soft, np.round(100.0 * decay ** (dists - r_hard)), 0),
+    ).astype(np.int8)
+    return kernel
+
+
 def inflate_grid(grid: np.ndarray, params: InflationParams) -> np.ndarray:
     """
     Inflate obstacles in a 2D occupancy grid.
@@ -39,29 +51,21 @@ def inflate_grid(grid: np.ndarray, params: InflationParams) -> np.ndarray:
     Returns:
         A new 2D `np.ndarray` (dtype `int8`) of the same shape containing the inflated occupancy values.
     """
-
     r_hard = params.inflation_radius_cells
     r_soft = params.inflation_falloff_radius_cells
     decay = params.inflation_decay_factor
     height, width = grid.shape
 
+    kernel = _make_inflation_kernel(r_hard, r_soft, decay)
     output = grid.astype(np.int8, copy=True)
 
-    def inflate(x: int, y: int) -> None:
-        for dx, dy in product(range(-r_soft, r_soft + 1), repeat=2):
-            dist = math.hypot(dx, dy)
-            if dist > r_soft:
-                continue
-
-            nx, ny = x + dx, y + dy
-            if not (0 <= nx < width) or not (0 <= ny < height):
-                continue
-
-            value = int(100 if dist <= r_hard else round(100 * (decay ** (dist - r_hard))))
-            output[ny, nx] = max(output[ny, nx], value)
-
     ys, xs = np.where(grid == 100)
-    for x, y in zip(xs.tolist(), ys.tolist(), strict=True):
-        inflate(x, y)
+    for y, x in zip(ys.tolist(), xs.tolist(), strict=True):
+        y0, y1 = max(0, y - r_soft), min(height, y + r_soft + 1)
+        x0, x1 = max(0, x - r_soft), min(width, x + r_soft + 1)
 
-    return output.astype(np.int8)
+        ky0, ky1 = y0 - (y - r_soft), y1 - (y - r_soft)
+        kx0, kx1 = x0 - (x - r_soft), x1 - (x - r_soft)
+        np.maximum(output[y0:y1, x0:x1], kernel[ky0:ky1, kx0:kx1], out=output[y0:y1, x0:x1])
+
+    return output


### PR DESCRIPTION
Closes #86 

## What has changed
1. The inflation layer is too slow that the calculation takes around 500ms. This is because each obstacle needs to do 41x41 calculations, so even a border of 300 obstacles would take ~500k calculations. This vectorizes the operation with numpy + kernel so that this can be up to date with occupancy grid input.
2. `occupancy_grid_simulator` was publishing in the wrong frame. It calculates occupancy value based on the ground truth position, but the grid should be published in `base_link` since that's what the CV pipeline does in real life
3. Rename `occ_grid` to `occupancy_grid` as changed by CV

## Testing plan
Tested running locally  
The topic is now published at the rate of `occupancy_grid/raw`  
Unit test passes  