### PR TITLE
Switch to modes and add helpers for launch files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,27 +14,36 @@ You can install all dependencies by running
 ./scripts/setup.sh
 ```
 
-## Configuration
+## Running the stack
+Run each of these commands in separate terminals:
+```bash
+ros2 launch nav_bringup base.launch.py mode:=<mode> [course:=<course>]
+```
+```bash
+ros2 launch nav_bringup teleop.launch.py controller:=<ps4/xbox>
+```
+and / or
+```bash
+ros2 launch nav_bringup navigation.launch.py mode:=<mode> [course:=<course>]
+```
+
+### Modes
+| Mode | Sensors | `odom`→`base_link` | `map`→`odom` | /goal source | `course` required |
+|---|---|---|---|---|---|
+| `autonav` | hardware | EKF | EKF | autonav_goal_selection | yes |
+| `autonav_sim` | simulated | EKF | EKF | autonav_goal_selection | yes |
+| `self_drive` | hardware | EKF | identity | CV | no |
+| `self_drive_sim` | simulated | EKF | identity | CV | yes |
+| `nav_test` | none | enc_odom | identity | manual | no |
+
+### Configuration
 Frame IDs and node parameters are defined in `nav_bringup/config/`. 
 To configure a new course, add a subfolder under `nav_bringup/courses/` containing:
 - `gps.json` — GPS datum and waypoints
 - `map.json` — simulation obstacle map
 
-Courses can be generated using the [course creation tool](https://github.com/umigv/course_creation_tool). The `default` 
-course is used when no `course` argument is provided.
-
-## Running the stack
-Run each of these commands in separate terminals:
-```bash
-ros2 launch nav_bringup base.launch.py [simulation:=true] [use_enc_odom:=true] [course:=<course>]
-```
-```bash
-ros2 launch nav_bringup teleop.launch.py controller:=<ps4/xbox> # teleop
-```
-and / or
-```bash
-ros2 launch nav_bringup navigation.launch.py [course:=<course>] # autonav
-```
+Courses can be generated using the [course creation tool](https://github.com/umigv/course_creation_tool). The `default`
+course is used when no `course` argument is provided. See `nav_bringup/courses/default/` for the expected schema.
 
 ## Visualization
 You can either 

--- a/README.md
+++ b/README.md
@@ -24,26 +24,13 @@ ros2 launch nav_bringup teleop.launch.py controller:=<ps4/xbox>
 ```
 and / or
 ```bash
-ros2 launch nav_bringup navigation.launch.py mode:=<mode> [course:=<course>]
+ros2 launch nav_bringup navigation.launch.py mode:=<mode>
 ```
 
-### Modes
-| Mode | Sensors | `odom`→`base_link` | `map`→`odom` | /goal source | `course` required |
-|---|---|---|---|---|---|
-| `autonav` | hardware | EKF | EKF | autonav_goal_selection | yes |
-| `autonav_sim` | simulated | EKF | EKF | autonav_goal_selection | yes |
-| `self_drive` | hardware | EKF | identity | CV | no |
-| `self_drive_sim` | simulated | EKF | identity | CV | yes |
-| `nav_test` | none | enc_odom | identity | manual | no |
+### Mode and Course Configuration
+See [nav_bringup/README.md](src/nav_infrastructure_simple/nav_bringup/README.md) for mode and course configuration 
+details.
 
-### Configuration
-Frame IDs and node parameters are defined in `nav_bringup/config/`. 
-To configure a new course, add a subfolder under `nav_bringup/courses/` containing:
-- `gps.json` — GPS datum and waypoints
-- `map.json` — simulation obstacle map
-
-Courses can be generated using the [course creation tool](https://github.com/umigv/course_creation_tool). The `default`
-course is used when no `course` argument is provided. See `nav_bringup/courses/default/` for the expected schema.
 
 ## Visualization
 You can either 

--- a/nav_bringup/README.md
+++ b/nav_bringup/README.md
@@ -1,15 +1,25 @@
 # nav_bringup
-Launch files and configuration for the navigation stack. See the root README for configuration and course data setup.
+Launch files and configuration for the navigation stack.
 
 
 ## Modes
 | Mode | Sensors | `odom`→`base_link` | `map`→`odom` | /goal source | `course` required |
 |---|---|---|---|---|---|
-| `autonav` | hardware | EKF | EKF | autonav_goal_selection | yes |
+| `autonav` | IMU + GPS | EKF | EKF | autonav_goal_selection | yes |
 | `autonav_sim` | simulated | EKF | EKF | autonav_goal_selection | yes |
-| `self_drive` | hardware | EKF | identity | CV | no |
+| `self_drive` | IMU | EKF | identity | CV | no |
 | `self_drive_sim` | simulated | EKF | identity | CV | yes |
 | `nav_test` | none | enc_odom | identity | manual | no |
+
+
+### Course Configuration
+Frame IDs and node parameters are defined in `nav_bringup/config/`. 
+To configure a new course, add a subfolder under `nav_bringup/courses/` containing:
+- `gps.json` — GPS datum and waypoints
+- `map.json` — simulation obstacle map
+
+Courses can be generated using the [course creation tool](https://github.com/umigv/course_creation_tool). The `default`
+course is used when no `course` argument is provided. See `nav_bringup/courses/default/` for the expected schema.
 
 
 ## base.launch.py
@@ -20,8 +30,9 @@ ros2 launch nav_bringup base.launch.py mode:=<mode> [course:=<course>]
 ```
 
 ### Parameters
-- `mode`: Operation mode (required)
-- `course`: Pass through to `sensors.launch.py` and `localization.launch.py`, default `default`
+- `mode`: Operation mode, passed through to sensors.launch.py and localization.launch.py (required)
+- `course`: Course profile, passed through to sensors.launch.py and localization.launch.py, default `default` (required 
+for `autonav`, `autonav_sim`, `self_drive_sim`)
 
 
 ## core.launch.py
@@ -35,7 +46,8 @@ ros2 launch nav_bringup core.launch.py
 Loads `marvin_description/urdf/marvin.xacro` and publishes TF transforms for all robot links.
 
 ### Foxglove Bridge
-Foxglove bridge is always started on `ws://localhost:8765`. Connect Foxglove Studio to this address to visualize the robot.
+Foxglove bridge is always started on `ws://localhost:8765`. Connect Foxglove Studio to this address to visualize the 
+robot.
 
 ### Subscribed Topics
 - `teleop_cmd_vel` (`geometry_msgs/Twist`) - Joystick velocity
@@ -73,18 +85,19 @@ ros2 launch nav_bringup sensors.launch.py mode:=<mode> [course:=<course>]
 
 ### Parameters
 - `mode`: Operation mode (required)
-- `course`: Course profile in `courses/` to load map and GPS datum from, default `default`
+- `course`: Course profile in `courses/` to load map and GPS datum from, default `default` (required for `autonav_sim`, 
+`self_drive_sim`)
 
 ### Published Topics (Hardware)
-- `imu/raw` (`sensor_msgs/Imu`) - Raw IMU data from VectorNav (autonav,  self_drive only)
-- `gps/raw` (`sensor_msgs/NavSatFix`) - Raw GPS fix from GPS receiver (autonav,  self_drive only)
+- `imu/raw` (`sensor_msgs/Imu`) - Raw IMU data from VectorNav (`autonav`, `self_drive`)
+- `gps/raw` (`sensor_msgs/NavSatFix`) - Raw GPS fix from GPS receiver (`autonav` only)
 
 ### Subscribed Topics (Simulation)
 - `cmd_vel` (`geometry_msgs/Twist`) - Velocity the robot is commanded to move in
 
 ### Published Topics (Simulation)
 - `imu/raw` (`sensor_msgs/Imu`) - Simulated IMU with Gaussian noise
-- `gps/raw` (`sensor_msgs/NavSatFix`) - Simulated GPS with noise and OU drift 
+- `gps/raw` (`sensor_msgs/NavSatFix`) - Simulated GPS with noise and OU drift
 - `enc_vel/raw` (`geometry_msgs/TwistWithCovarianceStamped`) - Simulated encoder velocity with noise and OU drift
 - `odom/ground_truth` (`nav_msgs/Odometry`) - Noiseless true pose in `map` frame
 (`child_frame_id = base_link_ground_truth`)
@@ -104,7 +117,8 @@ ros2 launch nav_bringup localization.launch.py mode:=<mode> [course:=<course>]
 
 ### Parameters
 - `mode`: Operation mode (required)
-- `course`: Course profile in `courses/` to load GPS datum from, default `default`
+- `course`: Course profile in `courses/` to load GPS datum from, default `default` (required for `autonav`, 
+`autonav_sim`)
 
 ### Subscribed Topics
 - `imu/raw` (`sensor_msgs/Imu`) - Raw IMU data (autonav*, self_drive* only)
@@ -143,7 +157,6 @@ ros2 launch nav_bringup teleop.launch.py controller:=<controller>
 
 ### Parameters
 - `controller`: Controller profile (`xbox` or `ps4`), required
-- `joystick_dev`: Joystick device path, default `/dev/input/js0`
 
 ### Controller Mappings
 For both Xbox and PS4:

--- a/nav_bringup/README.md
+++ b/nav_bringup/README.md
@@ -2,16 +2,25 @@
 Launch files and configuration for the navigation stack. See the root README for configuration and course data setup.
 
 
+## Modes
+| Mode | Sensors | `odom`→`base_link` | `map`→`odom` | /goal source | `course` required |
+|---|---|---|---|---|---|
+| `autonav` | hardware | EKF | EKF | autonav_goal_selection | yes |
+| `autonav_sim` | simulated | EKF | EKF | autonav_goal_selection | yes |
+| `self_drive` | hardware | EKF | identity | CV | no |
+| `self_drive_sim` | simulated | EKF | identity | CV | yes |
+| `nav_test` | none | enc_odom | identity | manual | no |
+
+
 ## base.launch.py
 Launches the base stack required for all operation modes: core, sensors, and localization.
 
 ```
-ros2 launch nav_bringup base.launch.py [simulation:=true] [use_enc_odom:=true] [course:=<course>]
+ros2 launch nav_bringup base.launch.py mode:=<mode> [course:=<course>]
 ```
 
 ### Parameters
-- `simulation`: Pass through to `sensors.launch.py`, default `false`
-- `use_enc_odom`: Pass through to `localization.launch.py`, default `false`
+- `mode`: Operation mode (required)
 - `course`: Pass through to `sensors.launch.py` and `localization.launch.py`, default `default`
 
 
@@ -56,67 +65,73 @@ If a higher-priority source stops publishing, control falls back to the next sou
 
 
 ## sensors.launch.py
-Launches sensor drivers. Supports a `simulation` mode that replaces real hardware with simulators.
+Launches sensor drivers
 
 ```
-ros2 launch nav_bringup sensors.launch.py [simulation:=true]
+ros2 launch nav_bringup sensors.launch.py mode:=<mode> [course:=<course>]
 ```
 
 ### Parameters
-- `simulation`: Launch sensor and occupancy grid simulators instead of real hardware drivers, default `false`
+- `mode`: Operation mode (required)
 - `course`: Course profile in `courses/` to load map and GPS datum from, default `default`
 
 ### Published Topics (Hardware)
-- `imu/raw` (`sensor_msgs/Imu`) - Raw IMU data from VectorNav
-- `gps/raw` (`sensor_msgs/NavSatFix`) - Raw GPS fix from GPS receiver
+- `imu/raw` (`sensor_msgs/Imu`) - Raw IMU data from VectorNav (autonav,  self_drive only)
+- `gps/raw` (`sensor_msgs/NavSatFix`) - Raw GPS fix from GPS receiver (autonav,  self_drive only)
+
+### Subscribed Topics (Simulation)
+- `cmd_vel` (`geometry_msgs/Twist`) - Velocity the robot is commanded to move in
 
 ### Published Topics (Simulation)
 - `imu/raw` (`sensor_msgs/Imu`) - Simulated IMU with Gaussian noise
-- `gps/raw` (`sensor_msgs/NavSatFix`) - Simulated GPS with noise and OU drift
+- `gps/raw` (`sensor_msgs/NavSatFix`) - Simulated GPS with noise and OU drift 
 - `enc_vel/raw` (`geometry_msgs/TwistWithCovarianceStamped`) - Simulated encoder velocity with noise and OU drift
 - `odom/ground_truth` (`nav_msgs/Odometry`) - Noiseless true pose in `map` frame
 (`child_frame_id = base_link_ground_truth`)
 - `occupancy_grid/raw` (`nav_msgs/OccupancyGrid`) - Robot-centric occupancy grid from static obstacle map
 - `occupancy_grid/ground_truth` (`nav_msgs/OccupancyGrid`) - Full static obstacle map (latched)
 
-### Broadcasted TF Frames
-- `map` → `base_link_ground_truth` (simulation mode only) - Noiseless true robot pose
+### Broadcasted TF Frames (Simulation)
+- `map` → `base_link_ground_truth` - Noiseless true robot pose
 
 
 ## localization.launch.py
 Launches localization
 
 ```
-ros2 launch nav_bringup localization.launch.py [use_enc_odom:=true]
+ros2 launch nav_bringup localization.launch.py mode:=<mode> [course:=<course>]
 ```
 
 ### Parameters
-- `use_enc_odom`: Use encoder odometry integration instead of EKF for local odometry, default `false`
+- `mode`: Operation mode (required)
 - `course`: Course profile in `courses/` to load GPS datum from, default `default`
 
 ### Subscribed Topics
-- `imu/raw` (`sensor_msgs/Imu`) - Raw IMU data
-- `gps/raw` (`sensor_msgs/NavSatFix`) - Raw GPS fix
+- `imu/raw` (`sensor_msgs/Imu`) - Raw IMU data (autonav*, self_drive* only)
+- `gps/raw` (`sensor_msgs/NavSatFix`) - Raw GPS fix (autonav* only)
 - `enc_vel/raw` (`geometry_msgs/TwistWithCovarianceStamped`) - Encoder velocity
 
 ### Published Topics
 - `odom/local` (`nav_msgs/Odometry`) - Local odometry in the odom frame
-- `odom/global` (`nav_msgs/Odometry`) - Global odometry in the map frame
+- `odom/global` (`nav_msgs/Odometry`) - Global odometry in the map frame (autonav* only)
 
 ### Broadcasted TF Frames
 - `odom` → `base_link`
 - `map` → `odom`
 
 ### Services
-- `fromLL` (`robot_localization/FromLL`) - Converts GPS latitude/longitude to a map-frame point
+- `fromLL` (`robot_localization/FromLL`) - Converts GPS latitude/longitude to a map-frame point (autonav* only)
 
 
 ## navigation.launch.py
 Launches the navigation stack.
 
 ```
-ros2 launch nav_bringup navigation.launch.py
+ros2 launch nav_bringup navigation.launch.py mode:=<mode>
 ```
+
+### Parameters
+- `mode`: Operation mode (required)
 
 
 ## teleop.launch.py

--- a/nav_bringup/launch/base.launch.py
+++ b/nav_bringup/launch/base.launch.py
@@ -11,19 +11,14 @@ def generate_launch_description() -> LaunchDescription:
     return LaunchDescription(
         [
             DeclareLaunchArgument(
-                "simulation",
-                default_value="false",
-                description="Launch sensor simulator instead of real hardware drivers",
-            ),
-            DeclareLaunchArgument(
-                "use_enc_odom",
-                default_value="false",
-                description="Replace ekf_local with encoder odometry integration",
+                "mode",
+                choices=["autonav", "autonav_sim", "self_drive", "self_drive_sim", "nav_test"],
+                description="autonav/autonav_sim: full GPS stack; self_drive/self_drive_sim: EKF local only; nav_test: enc_odom only",
             ),
             DeclareLaunchArgument(
                 "course",
                 default_value="default",
-                description="Course profile in courses/ to load map and GPS datum from",
+                description="Course profile in courses/ to load map and GPS datum from (required for autonav, autonav_sim, self_drive_sim)",
             ),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(PathJoinSubstitution([bringup_share, "launch", "core.launch.py"])),
@@ -31,7 +26,7 @@ def generate_launch_description() -> LaunchDescription:
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(PathJoinSubstitution([bringup_share, "launch", "sensors.launch.py"])),
                 launch_arguments=[
-                    ("simulation", LaunchConfiguration("simulation")),
+                    ("mode", LaunchConfiguration("mode")),
                     ("course", LaunchConfiguration("course")),
                 ],
             ),
@@ -40,7 +35,7 @@ def generate_launch_description() -> LaunchDescription:
                     PathJoinSubstitution([bringup_share, "launch", "localization.launch.py"])
                 ),
                 launch_arguments=[
-                    ("use_enc_odom", LaunchConfiguration("use_enc_odom")),
+                    ("mode", LaunchConfiguration("mode")),
                     ("course", LaunchConfiguration("course")),
                 ],
             ),

--- a/nav_bringup/launch/base.launch.py
+++ b/nav_bringup/launch/base.launch.py
@@ -3,6 +3,7 @@ from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
+from nav_bringup.launch_utils import MODES
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -12,13 +13,13 @@ def generate_launch_description() -> LaunchDescription:
         [
             DeclareLaunchArgument(
                 "mode",
-                choices=["autonav", "autonav_sim", "self_drive", "self_drive_sim", "nav_test"],
-                description="autonav/autonav_sim: full GPS stack; self_drive/self_drive_sim: EKF local only; nav_test: enc_odom only",
+                choices=MODES,
+                description="Operation mode, passed through to sensors.launch.py and localization.launch.py",
             ),
             DeclareLaunchArgument(
                 "course",
                 default_value="default",
-                description="Course profile in courses/ to load map and GPS datum from (required for autonav, autonav_sim, self_drive_sim)",
+                description="Course profile, passed through to sensors.launch.py and localization.launch.py (required for autonav, autonav_sim, self_drive_sim)",
             ),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(PathJoinSubstitution([bringup_share, "launch", "core.launch.py"])),

--- a/nav_bringup/launch/core.launch.py
+++ b/nav_bringup/launch/core.launch.py
@@ -1,24 +1,16 @@
-from pathlib import Path
-
-import yaml
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.substitutions import Command, PathJoinSubstitution
+from launch.substitutions import Command
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
-from launch_ros.substitutions import FindPackageShare
+from nav_bringup.launch_utils import bringup_share, load_frames
 
 
 def generate_launch_description() -> LaunchDescription:
-    bringup_share_dir = Path(get_package_share_directory("nav_bringup"))
-    bringup_share = FindPackageShare("nav_bringup")
+    frames = load_frames()
+    twist_mux_params = f"{bringup_share()}/config/core/twist_mux.yaml"
+    urdf = f"{get_package_share_directory('marvin_description')}/urdf/marvin.xacro"
 
-    with open(bringup_share_dir / "config" / "frames.yaml") as f:
-        frames = yaml.safe_load(f)
-
-    twist_mux_params = PathJoinSubstitution([bringup_share, "config", "core", "twist_mux.yaml"])
-
-    urdf = PathJoinSubstitution([FindPackageShare("marvin_description"), "urdf", "marvin.xacro"])
     # fmt: off
     robot_description = ParameterValue(
         Command(

--- a/nav_bringup/launch/localization.launch.py
+++ b/nav_bringup/launch/localization.launch.py
@@ -1,119 +1,106 @@
+from typing import assert_never
+
 from launch import LaunchDescription, LaunchDescriptionEntity
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from nav_bringup.launch_utils import bringup_share, load_frames, load_gps_file
+from nav_bringup.launch_utils import MODES, Mode, bringup_share, format_mode_description, load_frames, load_gps_file
 
 
 def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
     frames = load_frames()
-    mode = LaunchConfiguration("mode").perform(context)
+    mode: Mode = LaunchConfiguration("mode").perform(context)
+    course = LaunchConfiguration("course").perform(context)
+    gps_file = load_gps_file(course)
     localization_params = f"{bringup_share()}/config/localization/localization.yaml"
 
-    if mode == "nav_test":
-        return [
-            Node(
-                package="localization",
-                executable="enc_odom_publisher",
-                name="enc_odom_publisher",
-                output="screen",
-                parameters=[
-                    {"odom_frame_id": frames["odom_frame"]},
-                    {"base_frame_id": frames["base_frame"]},
-                ],
-                remappings=[
-                    ("enc_vel", "enc_vel/raw"),
-                    ("odom", "odom/local"),
-                ],
-            ),
-            Node(
-                package="tf2_ros",
-                executable="static_transform_publisher",
-                name="map_odom_publisher",
-                output="screen",
-                arguments=["0", "0", "0", "0", "0", "0", frames["map_frame"], frames["odom_frame"]],
-            ),
-        ]
-    elif mode.startswith("autonav"):
-        course = LaunchConfiguration("course").perform(context)
-        gps_file = load_gps_file(course)
+    ekf_local_node = Node(
+        package="robot_localization",
+        executable="ekf_node",
+        name="ekf_local",
+        output="screen",
+        parameters=[
+            localization_params,
+            {"map_frame": frames["map_frame"]},
+            {"odom_frame": frames["odom_frame"]},
+            {"base_link_frame": frames["base_frame"]},
+            {"world_frame": frames["odom_frame"]},
+        ],
+        remappings=[
+            ("odometry/filtered", "odom/local"),
+        ],
+    )
 
-        return [
-            Node(
-                package="robot_localization",
-                executable="ekf_node",
-                name="ekf_local",
-                output="screen",
-                parameters=[
-                    localization_params,
-                    {"map_frame": frames["map_frame"]},
-                    {"odom_frame": frames["odom_frame"]},
-                    {"base_link_frame": frames["base_frame"]},
-                    {"world_frame": frames["odom_frame"]},
-                ],
-                remappings=[
-                    ("odometry/filtered", "odom/local"),
-                ],
-            ),
-            Node(
-                package="robot_localization",
-                executable="navsat_transform_node",
-                name="navsat_transform",
-                output="screen",
-                parameters=[
-                    localization_params,
-                    {"datum": [gps_file["datum"]["latitude"], gps_file["datum"]["longitude"], 0.0]},
-                ],
-                remappings=[
-                    ("imu", "imu/raw"),
-                    ("gps/fix", "gps/raw"),
-                    ("odometry/filtered", "odom/global"),
-                    ("odometry/gps", "odom/gps"),
-                ],
-            ),
-            Node(
-                package="robot_localization",
-                executable="ekf_node",
-                name="ekf_global",
-                output="screen",
-                parameters=[
-                    localization_params,
-                    {"map_frame": frames["map_frame"]},
-                    {"odom_frame": frames["odom_frame"]},
-                    {"base_link_frame": frames["base_frame"]},
-                    {"world_frame": frames["map_frame"]},
-                ],
-                remappings=[
-                    ("odometry/filtered", "odom/global"),
-                ],
-            ),
-        ]
-    else:
-        return [
-            Node(
-                package="robot_localization",
-                executable="ekf_node",
-                name="ekf_local",
-                output="screen",
-                parameters=[
-                    localization_params,
-                    {"map_frame": frames["map_frame"]},
-                    {"odom_frame": frames["odom_frame"]},
-                    {"base_link_frame": frames["base_frame"]},
-                    {"world_frame": frames["odom_frame"]},
-                ],
-                remappings=[
-                    ("odometry/filtered", "odom/local"),
-                ],
-            ),
-            Node(
-                package="tf2_ros",
-                executable="static_transform_publisher",
-                name="map_odom_publisher",
-                output="screen",
-                arguments=["0", "0", "0", "0", "0", "0", frames["map_frame"], frames["odom_frame"]],
-            ),
-        ]
+    ekf_global_node = Node(
+        package="robot_localization",
+        executable="ekf_node",
+        name="ekf_global",
+        output="screen",
+        parameters=[
+            localization_params,
+            {"map_frame": frames["map_frame"]},
+            {"odom_frame": frames["odom_frame"]},
+            {"base_link_frame": frames["base_frame"]},
+            {"world_frame": frames["map_frame"]},
+        ],
+        remappings=[
+            ("odometry/filtered", "odom/global"),
+        ],
+    )
+
+    navsat_transform_node = Node(
+        package="robot_localization",
+        executable="navsat_transform_node",
+        name="navsat_transform",
+        output="screen",
+        parameters=[
+            localization_params,
+            {"datum": [gps_file["datum"]["latitude"], gps_file["datum"]["longitude"], 0.0]},
+        ],
+        remappings=[
+            ("imu", "imu/raw"),
+            ("gps/fix", "gps/raw"),
+            ("odometry/filtered", "odom/global"),
+            ("odometry/gps", "odom/gps"),
+        ],
+    )
+
+    enc_odom_node = Node(
+        package="localization",
+        executable="enc_odom_publisher",
+        name="enc_odom_publisher",
+        output="screen",
+        parameters=[
+            {"odom_frame_id": frames["odom_frame"]},
+            {"base_frame_id": frames["base_frame"]},
+        ],
+        remappings=[
+            ("enc_vel", "enc_vel/raw"),
+            ("odom", "odom/local"),
+        ],
+    )
+
+    identity_map_odom_node = Node(
+        package="tf2_ros",
+        executable="static_transform_publisher",
+        name="map_odom_publisher",
+        output="screen",
+        arguments=["0", "0", "0", "0", "0", "0", frames["map_frame"], frames["odom_frame"]],
+    )
+
+    match mode:
+        case "autonav":
+            return [ekf_local_node, navsat_transform_node, ekf_global_node]
+        case "autonav_sim":
+            return [ekf_local_node, navsat_transform_node, ekf_global_node]
+        case "self_drive":
+            return [ekf_local_node, identity_map_odom_node]
+        case "self_drive_sim":
+            return [ekf_local_node, identity_map_odom_node]
+        case "nav_test":
+            return [enc_odom_node, identity_map_odom_node]
+        case _:
+            assert_never(mode)  # type: ignore[unreachable]
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -121,8 +108,16 @@ def generate_launch_description() -> LaunchDescription:
         [
             DeclareLaunchArgument(
                 "mode",
-                choices=["autonav", "autonav_sim", "self_drive", "self_drive_sim", "nav_test"],
-                description="autonav/autonav_sim: full GPS stack; self_drive/self_drive_sim: EKF local only; nav_test: enc_odom only",
+                choices=MODES,
+                description=format_mode_description(
+                    {
+                        "autonav": "EKF local + navsat transform + EKF global",
+                        "autonav_sim": "EKF local + navsat transform + EKF global",
+                        "self_drive": "EKF local + identity map->odom",
+                        "self_drive_sim": "EKF local + identity map->odom",
+                        "nav_test": "enc_odom + identity map->odom",
+                    }
+                ),
             ),
             DeclareLaunchArgument(
                 "course",

--- a/nav_bringup/launch/localization.launch.py
+++ b/nav_bringup/launch/localization.launch.py
@@ -1,110 +1,133 @@
-import json
-from pathlib import Path
-
-import yaml
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription, LaunchDescriptionEntity
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.conditions import IfCondition, UnlessCondition
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from launch_ros.substitutions import FindPackageShare
+from nav_bringup.launch_utils import bringup_share, load_frames, load_gps_file
 
 
 def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
-    bringup_share_dir = Path(get_package_share_directory("nav_bringup"))
-    bringup_share = FindPackageShare("nav_bringup")
+    frames = load_frames()
+    mode = LaunchConfiguration("mode").perform(context)
+    localization_params = f"{bringup_share()}/config/localization/localization.yaml"
 
-    with open(bringup_share_dir / "config" / "frames.yaml") as f:
-        frames = yaml.safe_load(f)
+    if mode == "nav_test":
+        return [
+            Node(
+                package="localization",
+                executable="enc_odom_publisher",
+                name="enc_odom_publisher",
+                output="screen",
+                parameters=[
+                    {"odom_frame_id": frames["odom_frame"]},
+                    {"base_frame_id": frames["base_frame"]},
+                ],
+                remappings=[
+                    ("enc_vel", "enc_vel/raw"),
+                    ("odom", "odom/local"),
+                ],
+            ),
+            Node(
+                package="tf2_ros",
+                executable="static_transform_publisher",
+                name="map_odom_publisher",
+                output="screen",
+                arguments=["0", "0", "0", "0", "0", "0", frames["map_frame"], frames["odom_frame"]],
+            ),
+        ]
+    elif mode.startswith("autonav"):
+        course = LaunchConfiguration("course").perform(context)
+        gps_file = load_gps_file(course)
 
-    course = LaunchConfiguration("course").perform(context)
-    with open(bringup_share_dir / "courses" / course / "gps.json") as f:
-        gps_file = json.load(f)
-
-    localization_params = PathJoinSubstitution([bringup_share, "config", "localization", "localization.yaml"])
-    use_enc_odom = LaunchConfiguration("use_enc_odom")
-
-    return [
-        Node(
-            package="robot_localization",
-            executable="ekf_node",
-            name="ekf_local",
-            output="screen",
-            condition=UnlessCondition(use_enc_odom),
-            parameters=[
-                localization_params,
-                {"map_frame": frames["map_frame"]},
-                {"odom_frame": frames["odom_frame"]},
-                {"base_link_frame": frames["base_frame"]},
-                {"world_frame": frames["odom_frame"]},
-            ],
-            remappings=[
-                ("odometry/filtered", "odom/local"),
-            ],
-        ),
-        Node(
-            package="localization",
-            executable="enc_odom_publisher",
-            name="enc_odom_publisher",
-            output="screen",
-            condition=IfCondition(use_enc_odom),
-            parameters=[
-                {"odom_frame_id": frames["odom_frame"]},
-                {"base_frame_id": frames["base_frame"]},
-            ],
-            remappings=[
-                ("enc_vel", "enc_vel/raw"),
-                ("odom", "odom/local"),
-            ],
-        ),
-        Node(
-            package="robot_localization",
-            executable="navsat_transform_node",
-            name="navsat_transform",
-            output="screen",
-            parameters=[
-                localization_params,
-                {"datum": [gps_file["datum"]["latitude"], gps_file["datum"]["longitude"], 0.0]},
-            ],
-            remappings=[
-                ("imu", "imu/raw"),
-                ("gps/fix", "gps/raw"),
-                ("odometry/filtered", "odom/global"),
-                ("odometry/gps", "odom/gps"),
-            ],
-        ),
-        Node(
-            package="robot_localization",
-            executable="ekf_node",
-            name="ekf_global",
-            output="screen",
-            parameters=[
-                localization_params,
-                {"map_frame": frames["map_frame"]},
-                {"odom_frame": frames["odom_frame"]},
-                {"base_link_frame": frames["base_frame"]},
-                {"world_frame": frames["map_frame"]},
-            ],
-            remappings=[
-                ("odometry/filtered", "odom/global"),
-            ],
-        ),
-    ]
+        return [
+            Node(
+                package="robot_localization",
+                executable="ekf_node",
+                name="ekf_local",
+                output="screen",
+                parameters=[
+                    localization_params,
+                    {"map_frame": frames["map_frame"]},
+                    {"odom_frame": frames["odom_frame"]},
+                    {"base_link_frame": frames["base_frame"]},
+                    {"world_frame": frames["odom_frame"]},
+                ],
+                remappings=[
+                    ("odometry/filtered", "odom/local"),
+                ],
+            ),
+            Node(
+                package="robot_localization",
+                executable="navsat_transform_node",
+                name="navsat_transform",
+                output="screen",
+                parameters=[
+                    localization_params,
+                    {"datum": [gps_file["datum"]["latitude"], gps_file["datum"]["longitude"], 0.0]},
+                ],
+                remappings=[
+                    ("imu", "imu/raw"),
+                    ("gps/fix", "gps/raw"),
+                    ("odometry/filtered", "odom/global"),
+                    ("odometry/gps", "odom/gps"),
+                ],
+            ),
+            Node(
+                package="robot_localization",
+                executable="ekf_node",
+                name="ekf_global",
+                output="screen",
+                parameters=[
+                    localization_params,
+                    {"map_frame": frames["map_frame"]},
+                    {"odom_frame": frames["odom_frame"]},
+                    {"base_link_frame": frames["base_frame"]},
+                    {"world_frame": frames["map_frame"]},
+                ],
+                remappings=[
+                    ("odometry/filtered", "odom/global"),
+                ],
+            ),
+        ]
+    else:
+        return [
+            Node(
+                package="robot_localization",
+                executable="ekf_node",
+                name="ekf_local",
+                output="screen",
+                parameters=[
+                    localization_params,
+                    {"map_frame": frames["map_frame"]},
+                    {"odom_frame": frames["odom_frame"]},
+                    {"base_link_frame": frames["base_frame"]},
+                    {"world_frame": frames["odom_frame"]},
+                ],
+                remappings=[
+                    ("odometry/filtered", "odom/local"),
+                ],
+            ),
+            Node(
+                package="tf2_ros",
+                executable="static_transform_publisher",
+                name="map_odom_publisher",
+                output="screen",
+                arguments=["0", "0", "0", "0", "0", "0", frames["map_frame"], frames["odom_frame"]],
+            ),
+        ]
 
 
 def generate_launch_description() -> LaunchDescription:
     return LaunchDescription(
         [
             DeclareLaunchArgument(
-                "course",
-                default_value="default",
-                description="Course profile in courses/ to load GPS datum from",
+                "mode",
+                choices=["autonav", "autonav_sim", "self_drive", "self_drive_sim", "nav_test"],
+                description="autonav/autonav_sim: full GPS stack; self_drive/self_drive_sim: EKF local only; nav_test: enc_odom only",
             ),
             DeclareLaunchArgument(
-                "use_enc_odom",
-                default_value="false",
-                description="Replace ekf_local with encoder odometry integration",
+                "course",
+                default_value="default",
+                description="Course profile in courses/ to load GPS datum from (required for autonav, autonav_sim)",
             ),
             OpaqueFunction(function=launch_setup),
         ]

--- a/nav_bringup/launch/navigation.launch.py
+++ b/nav_bringup/launch/navigation.launch.py
@@ -1,31 +1,46 @@
-from pathlib import Path
-
-import yaml
-from ament_index_python.packages import get_package_share_directory
-from launch import LaunchDescription
+from launch import LaunchDescription, LaunchDescriptionEntity
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from nav_bringup.launch_utils import load_frames
 
 
-def generate_launch_description() -> LaunchDescription:
-    bringup_share_dir = Path(get_package_share_directory("nav_bringup"))
+def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
+    frames = load_frames()
+    mode = LaunchConfiguration("mode").perform(context)
 
-    with open(bringup_share_dir / "config" / "frames.yaml") as f:
-        frames = yaml.safe_load(f)
+    nodes = [
+        Node(
+            package="occupancy_grid_transform",
+            executable="occupancy_grid_transform",
+            name="occupancy_grid_transform",
+            parameters=[
+                {"frame_id": frames["odom_frame"]},
+            ],
+            remappings=[
+                ("occupancy_grid", "occupancy_grid/raw"),
+                ("transformed_occupancy_grid", "inflated_occupancy_grid"),
+            ],
+        ),
+        Node(
+            package="path_tracking",
+            executable="path_tracking",
+            name="path_tracking",
+            parameters=[
+                {"base_frame_id": frames["base_frame"]},
+                {"odom_frame_id": frames["odom_frame"]},
+            ],
+            remappings=[
+                ("odom", "odom/local"),
+                ("path", "path"),
+                ("nav_cmd_vel", "nav_cmd_vel"),
+                ("smoothed_path", "smoothed_path"),
+            ],
+        ),
+    ]
 
-    return LaunchDescription(
-        [
-            Node(
-                package="occupancy_grid_transform",
-                executable="occupancy_grid_transform",
-                name="occupancy_grid_transform",
-                parameters=[
-                    {"frame_id": frames["odom_frame"]},
-                ],
-                remappings=[
-                    ("occupancy_grid", "occupancy_grid/raw"),
-                    ("transformed_occupancy_grid", "inflated_occupancy_grid"),
-                ],
-            ),
+    if mode.startswith("autonav"):
+        nodes.append(
             Node(
                 package="goal_selection",
                 executable="goal_selection",
@@ -36,21 +51,20 @@ def generate_launch_description() -> LaunchDescription:
                     ("inflated_occupancy_grid", "inflated_occupancy_grid"),
                     ("path", "path"),
                 ],
+            )
+        )
+
+    return nodes
+
+
+def generate_launch_description() -> LaunchDescription:
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "mode",
+                choices=["autonav", "autonav_sim", "self_drive", "self_drive_sim", "nav_test"],
+                description="autonav/autonav_sim: full GPS stack; self_drive/self_drive_sim: EKF local only; nav_test: enc_odom only",
             ),
-            Node(
-                package="path_tracking",
-                executable="path_tracking",
-                name="path_tracking",
-                parameters=[
-                    {"base_frame_id": frames["base_frame"]},
-                    {"odom_frame_id": frames["odom_frame"]},
-                ],
-                remappings=[
-                    ("odom", "odom/local"),
-                    ("path", "path"),
-                    ("nav_cmd_vel", "nav_cmd_vel"),
-                    ("smoothed_path", "smoothed_path"),
-                ],
-            ),
+            OpaqueFunction(function=launch_setup),
         ]
     )

--- a/nav_bringup/launch/navigation.launch.py
+++ b/nav_bringup/launch/navigation.launch.py
@@ -1,60 +1,70 @@
+from typing import assert_never
+
 from launch import LaunchDescription, LaunchDescriptionEntity
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from nav_bringup.launch_utils import load_frames
+from nav_bringup.launch_utils import MODES, Mode, format_mode_description, load_frames
 
 
 def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
     frames = load_frames()
-    mode = LaunchConfiguration("mode").perform(context)
+    mode: Mode = LaunchConfiguration("mode").perform(context)
 
-    nodes = [
-        Node(
-            package="occupancy_grid_transform",
-            executable="occupancy_grid_transform",
-            name="occupancy_grid_transform",
-            parameters=[
-                {"frame_id": frames["odom_frame"]},
-            ],
-            remappings=[
-                ("occupancy_grid", "occupancy_grid/raw"),
-                ("transformed_occupancy_grid", "inflated_occupancy_grid"),
-            ],
-        ),
-        Node(
-            package="path_tracking",
-            executable="path_tracking",
-            name="path_tracking",
-            parameters=[
-                {"base_frame_id": frames["base_frame"]},
-                {"odom_frame_id": frames["odom_frame"]},
-            ],
-            remappings=[
-                ("odom", "odom/local"),
-                ("path", "path"),
-                ("nav_cmd_vel", "nav_cmd_vel"),
-                ("smoothed_path", "smoothed_path"),
-            ],
-        ),
-    ]
+    occupancy_grid_transform_node = Node(
+        package="occupancy_grid_transform",
+        executable="occupancy_grid_transform",
+        name="occupancy_grid_transform",
+        parameters=[
+            {"frame_id": frames["odom_frame"]},
+        ],
+        remappings=[
+            ("occupancy_grid", "occupancy_grid/raw"),
+            ("transformed_occupancy_grid", "inflated_occupancy_grid"),
+        ],
+    )
 
-    if mode.startswith("autonav"):
-        nodes.append(
-            Node(
-                package="goal_selection",
-                executable="goal_selection",
-                name="goal_selection",
-                remappings=[
-                    ("odom", "odom/local"),
-                    ("gps_coords", "gps/raw"),
-                    ("inflated_occupancy_grid", "inflated_occupancy_grid"),
-                    ("path", "path"),
-                ],
-            )
-        )
+    path_tracking_node = Node(
+        package="path_tracking",
+        executable="path_tracking",
+        name="path_tracking",
+        parameters=[
+            {"base_frame_id": frames["base_frame"]},
+            {"odom_frame_id": frames["odom_frame"]},
+        ],
+        remappings=[
+            ("odom", "odom/local"),
+            ("path", "path"),
+            ("nav_cmd_vel", "nav_cmd_vel"),
+            ("smoothed_path", "smoothed_path"),
+        ],
+    )
 
-    return nodes
+    goal_selection_node = Node(
+        package="goal_selection",
+        executable="goal_selection",
+        name="goal_selection",
+        remappings=[
+            ("odom", "odom/local"),
+            ("gps_coords", "gps/raw"),
+            ("inflated_occupancy_grid", "inflated_occupancy_grid"),
+            ("path", "path"),
+        ],
+    )
+
+    match mode:
+        case "autonav":
+            return [occupancy_grid_transform_node, path_tracking_node, goal_selection_node]
+        case "autonav_sim":
+            return [occupancy_grid_transform_node, path_tracking_node, goal_selection_node]
+        case "self_drive":
+            return [occupancy_grid_transform_node, path_tracking_node]
+        case "self_drive_sim":
+            return [occupancy_grid_transform_node, path_tracking_node]
+        case "nav_test":
+            return [occupancy_grid_transform_node, path_tracking_node]
+        case _:
+            assert_never(mode)  # type: ignore[unreachable]
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -62,8 +72,16 @@ def generate_launch_description() -> LaunchDescription:
         [
             DeclareLaunchArgument(
                 "mode",
-                choices=["autonav", "autonav_sim", "self_drive", "self_drive_sim", "nav_test"],
-                description="autonav/autonav_sim: full GPS stack; self_drive/self_drive_sim: EKF local only; nav_test: enc_odom only",
+                choices=MODES,
+                description=format_mode_description(
+                    {
+                        "autonav": "occupancy grid transform + path tracking + goal selection",
+                        "autonav_sim": "occupancy grid transform + path tracking + goal selection",
+                        "self_drive": "occupancy grid transform + path tracking",
+                        "self_drive_sim": "occupancy grid transform + path tracking",
+                        "nav_test": "occupancy grid transform + path tracking",
+                    }
+                ),
             ),
             OpaqueFunction(function=launch_setup),
         ]

--- a/nav_bringup/launch/sensors.launch.py
+++ b/nav_bringup/launch/sensors.launch.py
@@ -1,118 +1,100 @@
-import json
-from pathlib import Path
-
-import yaml
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription, LaunchDescriptionEntity
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.conditions import IfCondition, UnlessCondition
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from launch_ros.substitutions import FindPackageShare
+from nav_bringup.launch_utils import bringup_share, load_frames, load_gps_file
 
 
 def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
-    bringup_share_dir = Path(get_package_share_directory("nav_bringup"))
-    bringup_share = FindPackageShare("nav_bringup")
+    frames = load_frames()
+    mode = LaunchConfiguration("mode").perform(context)
 
-    with open(bringup_share_dir / "config" / "frames.yaml") as f:
-        frames = yaml.safe_load(f)
+    if mode == "nav_test":
+        return []
+    elif mode.endswith("_sim"):
+        course = LaunchConfiguration("course").perform(context)
+        gps_file = load_gps_file(course)
 
-    course = LaunchConfiguration("course").perform(context)
-    with open(bringup_share_dir / "courses" / course / "gps.json") as f:
-        gps_file = json.load(f)
-
-    imu_params = PathJoinSubstitution([bringup_share, "config", "sensors", "imu.yaml"])
-    gps_params = PathJoinSubstitution([bringup_share, "config", "sensors", "gps.yaml"])
-    sensor_simulator_params = PathJoinSubstitution([bringup_share, "config", "sensors", "sensor_simulator.yaml"])
-    simulation = LaunchConfiguration("simulation")
-    map_file = PathJoinSubstitution([bringup_share, "courses", course, "map.json"])
-
-    return [
-        Node(
-            package="vectornav",
-            executable="vectornav_node",
-            name="vectornav",
-            output="screen",
-            condition=UnlessCondition(simulation),
-            parameters=[
-                imu_params,
-                {"frame_id": frames["imu_frame"]},
-                {"map_frame_id": frames["map_frame"]},
-            ],
-            remappings=[
-                ("vectornav/data", "imu/raw"),
-            ],
-        ),
-        Node(
-            package="gps_publisher",
-            executable="gps_publisher",
-            name="gps_publisher",
-            output="screen",
-            condition=UnlessCondition(simulation),
-            parameters=[
-                gps_params,
-                {"gps_frame_id": frames["gps_frame"]},
-            ],
-            remappings=[
-                ("gps", "gps/raw"),
-            ],
-        ),
-        Node(
-            package="sensor_simulator",
-            executable="sensor_simulator",
-            name="sensor_simulator",
-            output="screen",
-            condition=IfCondition(simulation),
-            parameters=[
-                sensor_simulator_params,
-                {
-                    "map_frame_id": frames["map_frame"],
-                    "base_frame_id": frames["base_frame"],
-                    "ground_truth_base_frame_id": frames["ground_truth_base_frame"],
-                    "imu_frame_id": frames["imu_frame"],
-                    "gps_frame_id": frames["gps_frame"],
-                    "gps.origin_latitude_deg": gps_file["datum"]["latitude"],
-                    "gps.origin_longitude_deg": gps_file["datum"]["longitude"],
-                },
-            ],
-            remappings=[
-                ("gps", "gps/raw"),
-                ("enc_vel", "enc_vel/raw"),
-                ("imu", "imu/raw"),
-                ("odom/ground_truth", "odom/ground_truth"),
-            ],
-        ),
-        Node(
-            package="occupancy_grid_simulator",
-            executable="occupancy_grid_simulator",
-            name="occupancy_grid_simulator",
-            output="screen",
-            condition=IfCondition(simulation),
-            parameters=[
-                {
-                    "map_file_path": map_file,
-                    "map_frame_id": frames["map_frame"],
-                    "base_frame_id": frames["base_frame"],
-                    "ground_truth_base_frame_id": frames["ground_truth_base_frame"],
-                }
-            ],
-            remappings=[
-                ("odom", "odom/ground_truth"),
-                ("occupancy_grid", "occupancy_grid/raw"),
-                ("occupancy_grid/ground_truth", "occupancy_grid/ground_truth"),
-            ],
-        ),
-    ]
+        return [
+            Node(
+                package="sensor_simulator",
+                executable="sensor_simulator",
+                name="sensor_simulator",
+                output="screen",
+                parameters=[
+                    f"{bringup_share()}/config/sensors/sensor_simulator.yaml",
+                    {"map_frame_id": frames["map_frame"]},
+                    {"base_frame_id": frames["base_frame"]},
+                    {"ground_truth_base_frame_id": frames["ground_truth_base_frame"]},
+                    {"imu_frame_id": frames["imu_frame"]},
+                    {"gps_frame_id": frames["gps_frame"]},
+                    {"gps.origin_latitude_deg": gps_file["datum"]["latitude"]},
+                    {"gps.origin_longitude_deg": gps_file["datum"]["longitude"]},
+                ],
+                remappings=[
+                    ("gps", "gps/raw"),
+                    ("enc_vel", "enc_vel/raw"),
+                    ("imu", "imu/raw"),
+                    ("odom/ground_truth", "odom/ground_truth"),
+                ],
+            ),
+            Node(
+                package="occupancy_grid_simulator",
+                executable="occupancy_grid_simulator",
+                name="occupancy_grid_simulator",
+                output="screen",
+                parameters=[
+                    {"map_file_path": f"{bringup_share()}/courses/{course}/map.json"},
+                    {"map_frame_id": frames["map_frame"]},
+                    {"base_frame_id": frames["base_frame"]},
+                    {"ground_truth_base_frame_id": frames["ground_truth_base_frame"]},
+                ],
+                remappings=[
+                    ("odom", "odom/ground_truth"),
+                    ("occupancy_grid", "occupancy_grid/raw"),
+                    ("occupancy_grid/ground_truth", "occupancy_grid/ground_truth"),
+                ],
+            ),
+        ]
+    else:
+        return [
+            Node(
+                package="vectornav",
+                executable="vectornav_node",
+                name="vectornav",
+                output="screen",
+                parameters=[
+                    f"{bringup_share()}/config/sensors/imu.yaml",
+                    {"frame_id": frames["imu_frame"]},
+                    {"map_frame_id": frames["map_frame"]},
+                ],
+                remappings=[
+                    ("vectornav/data", "imu/raw"),
+                ],
+            ),
+            Node(
+                package="gps_publisher",
+                executable="gps_publisher",
+                name="gps_publisher",
+                output="screen",
+                parameters=[
+                    f"{bringup_share()}/config/sensors/gps.yaml",
+                    {"gps_frame_id": frames["gps_frame"]},
+                ],
+                remappings=[
+                    ("gps", "gps/raw"),
+                ],
+            ),
+        ]
 
 
 def generate_launch_description() -> LaunchDescription:
     return LaunchDescription(
         [
             DeclareLaunchArgument(
-                "simulation",
-                default_value="false",
-                description="Launch sensor simulator instead of real hardware drivers",
+                "mode",
+                choices=["autonav", "autonav_sim", "self_drive", "self_drive_sim", "nav_test"],
+                description="autonav/autonav_sim: full GPS stack; self_drive/self_drive_sim: EKF local only; nav_test: enc_odom only",
             ),
             DeclareLaunchArgument(
                 "course",

--- a/nav_bringup/launch/sensors.launch.py
+++ b/nav_bringup/launch/sensors.launch.py
@@ -1,91 +1,102 @@
+from typing import assert_never
+
 from launch import LaunchDescription, LaunchDescriptionEntity
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from nav_bringup.launch_utils import bringup_share, load_frames, load_gps_file
+from nav_bringup.launch_utils import MODES, Mode, bringup_share, format_mode_description, load_frames, load_gps_file
 
 
 def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
     frames = load_frames()
-    mode = LaunchConfiguration("mode").perform(context)
+    mode: Mode = LaunchConfiguration("mode").perform(context)
+    course = LaunchConfiguration("course").perform(context)
+    gps_file = load_gps_file(course)
+    share = bringup_share()
 
-    if mode == "nav_test":
-        return []
-    elif mode.endswith("_sim"):
-        course = LaunchConfiguration("course").perform(context)
-        gps_file = load_gps_file(course)
+    imu_node = Node(
+        package="vectornav",
+        executable="vectornav_node",
+        name="vectornav",
+        output="screen",
+        parameters=[
+            f"{share}/config/sensors/imu.yaml",
+            {"frame_id": frames["imu_frame"]},
+            {"map_frame_id": frames["map_frame"]},
+        ],
+        remappings=[
+            ("vectornav/data", "imu/raw"),
+        ],
+    )
 
-        return [
-            Node(
-                package="sensor_simulator",
-                executable="sensor_simulator",
-                name="sensor_simulator",
-                output="screen",
-                parameters=[
-                    f"{bringup_share()}/config/sensors/sensor_simulator.yaml",
-                    {"map_frame_id": frames["map_frame"]},
-                    {"base_frame_id": frames["base_frame"]},
-                    {"ground_truth_base_frame_id": frames["ground_truth_base_frame"]},
-                    {"imu_frame_id": frames["imu_frame"]},
-                    {"gps_frame_id": frames["gps_frame"]},
-                    {"gps.origin_latitude_deg": gps_file["datum"]["latitude"]},
-                    {"gps.origin_longitude_deg": gps_file["datum"]["longitude"]},
-                ],
-                remappings=[
-                    ("gps", "gps/raw"),
-                    ("enc_vel", "enc_vel/raw"),
-                    ("imu", "imu/raw"),
-                    ("odom/ground_truth", "odom/ground_truth"),
-                ],
-            ),
-            Node(
-                package="occupancy_grid_simulator",
-                executable="occupancy_grid_simulator",
-                name="occupancy_grid_simulator",
-                output="screen",
-                parameters=[
-                    {"map_file_path": f"{bringup_share()}/courses/{course}/map.json"},
-                    {"map_frame_id": frames["map_frame"]},
-                    {"base_frame_id": frames["base_frame"]},
-                    {"ground_truth_base_frame_id": frames["ground_truth_base_frame"]},
-                ],
-                remappings=[
-                    ("odom", "odom/ground_truth"),
-                    ("occupancy_grid", "occupancy_grid/raw"),
-                    ("occupancy_grid/ground_truth", "occupancy_grid/ground_truth"),
-                ],
-            ),
-        ]
-    else:
-        return [
-            Node(
-                package="vectornav",
-                executable="vectornav_node",
-                name="vectornav",
-                output="screen",
-                parameters=[
-                    f"{bringup_share()}/config/sensors/imu.yaml",
-                    {"frame_id": frames["imu_frame"]},
-                    {"map_frame_id": frames["map_frame"]},
-                ],
-                remappings=[
-                    ("vectornav/data", "imu/raw"),
-                ],
-            ),
-            Node(
-                package="gps_publisher",
-                executable="gps_publisher",
-                name="gps_publisher",
-                output="screen",
-                parameters=[
-                    f"{bringup_share()}/config/sensors/gps.yaml",
-                    {"gps_frame_id": frames["gps_frame"]},
-                ],
-                remappings=[
-                    ("gps", "gps/raw"),
-                ],
-            ),
-        ]
+    gps_node = Node(
+        package="gps_publisher",
+        executable="gps_publisher",
+        name="gps_publisher",
+        output="screen",
+        parameters=[
+            f"{share}/config/sensors/gps.yaml",
+            {"gps_frame_id": frames["gps_frame"]},
+        ],
+        remappings=[
+            ("gps", "gps/raw"),
+        ],
+    )
+
+    sensor_simulator_node = Node(
+        package="sensor_simulator",
+        executable="sensor_simulator",
+        name="sensor_simulator",
+        output="screen",
+        parameters=[
+            f"{share}/config/sensors/sensor_simulator.yaml",
+            {"map_frame_id": frames["map_frame"]},
+            {"base_frame_id": frames["base_frame"]},
+            {"ground_truth_base_frame_id": frames["ground_truth_base_frame"]},
+            {"imu_frame_id": frames["imu_frame"]},
+            {"gps_frame_id": frames["gps_frame"]},
+            {"gps.origin_latitude_deg": gps_file["datum"]["latitude"]},
+            {"gps.origin_longitude_deg": gps_file["datum"]["longitude"]},
+        ],
+        remappings=[
+            ("gps", "gps/raw"),
+            ("enc_vel", "enc_vel/raw"),
+            ("imu", "imu/raw"),
+            ("odom/ground_truth", "odom/ground_truth"),
+        ],
+    )
+
+    occupancy_grid_simulator_node = Node(
+        package="occupancy_grid_simulator",
+        executable="occupancy_grid_simulator",
+        name="occupancy_grid_simulator",
+        output="screen",
+        parameters=[
+            {"map_file_path": f"{share}/courses/{course}/map.json"},
+            {"map_frame_id": frames["map_frame"]},
+            {"base_frame_id": frames["base_frame"]},
+            {"ground_truth_base_frame_id": frames["ground_truth_base_frame"]},
+        ],
+        remappings=[
+            ("odom", "odom/ground_truth"),
+            ("occupancy_grid", "occupancy_grid/raw"),
+            ("occupancy_grid/ground_truth", "occupancy_grid/ground_truth"),
+        ],
+    )
+
+    match mode:
+        case "autonav":
+            return [imu_node, gps_node]
+        case "autonav_sim":
+            return [sensor_simulator_node, occupancy_grid_simulator_node]
+        case "self_drive":
+            return [imu_node]
+        case "self_drive_sim":
+            return [sensor_simulator_node, occupancy_grid_simulator_node]
+        case "nav_test":
+            return []
+        case _:
+            assert_never(mode)  # type: ignore[unreachable]
 
 
 def generate_launch_description() -> LaunchDescription:
@@ -93,13 +104,21 @@ def generate_launch_description() -> LaunchDescription:
         [
             DeclareLaunchArgument(
                 "mode",
-                choices=["autonav", "autonav_sim", "self_drive", "self_drive_sim", "nav_test"],
-                description="autonav/autonav_sim: full GPS stack; self_drive/self_drive_sim: EKF local only; nav_test: enc_odom only",
+                choices=MODES,
+                description=format_mode_description(
+                    {
+                        "autonav": "IMU + GPS",
+                        "autonav_sim": "sensor simulator + occupancy grid simulator",
+                        "self_drive": "IMU only",
+                        "self_drive_sim": "sensor simulator + occupancy grid simulator",
+                        "nav_test": "no sensors",
+                    }
+                ),
             ),
             DeclareLaunchArgument(
                 "course",
                 default_value="default",
-                description="Course profile in courses/ to load map and GPS datum from",
+                description="Course profile in courses/ to load map and GPS datum from (required for autonav_sim, self_drive_sim)",
             ),
             OpaqueFunction(function=launch_setup),
         ]

--- a/nav_bringup/launch/teleop.launch.py
+++ b/nav_bringup/launch/teleop.launch.py
@@ -1,22 +1,16 @@
-from pathlib import Path
-
-import yaml
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription, LaunchDescriptionEntity
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from nav_bringup.launch_utils import bringup_share, load_frames
 
 CONTROLLERS = ("ps4", "xbox")
 
 
 def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
-    bringup_share = get_package_share_directory("nav_bringup")
+    frames = load_frames()
     controller = LaunchConfiguration("controller").perform(context).strip().lower()
-    teleop_params = PathJoinSubstitution([bringup_share, "config", "teleop", f"teleop_{controller}.yaml"])
-
-    with open(Path(bringup_share) / "config" / "frames.yaml") as f:
-        frames = yaml.safe_load(f)
+    teleop_params = f"{bringup_share()}/config/teleop/teleop_{controller}.yaml"
 
     return [
         Node(

--- a/nav_bringup/nav_bringup/launch_utils.py
+++ b/nav_bringup/nav_bringup/launch_utils.py
@@ -1,7 +1,19 @@
 import json
+from typing import Literal, get_args
 
 import yaml
 from ament_index_python.packages import get_package_share_directory
+
+Mode = Literal["autonav", "autonav_sim", "self_drive", "self_drive_sim", "nav_test"]
+MODES: list[Mode] = list(get_args(Mode))
+
+
+def format_mode_description(descriptions: dict[Mode, str]) -> str:
+    if missing := set(MODES) - descriptions.keys():
+        raise ValueError(f"format_mode_description: missing modes: {missing}")
+    mode_pad = max(len(m) for m in MODES) + 2  # +2 for ": "
+    lines = [f"{mode}:{' ' * (mode_pad - len(mode) - 1)}{descriptions[mode]}" for mode in MODES]
+    return "\n        ".join(lines) + "\n        "
 
 
 def bringup_share() -> str:

--- a/nav_bringup/nav_bringup/launch_utils.py
+++ b/nav_bringup/nav_bringup/launch_utils.py
@@ -1,0 +1,18 @@
+import json
+
+import yaml
+from ament_index_python.packages import get_package_share_directory
+
+
+def bringup_share() -> str:
+    return get_package_share_directory("nav_bringup")
+
+
+def load_frames() -> dict:
+    with open(f"{bringup_share()}/config/frames.yaml") as f:
+        return yaml.safe_load(f)
+
+
+def load_gps_file(course: str) -> dict:
+    with open(f"{bringup_share()}/courses/{course}/gps.json") as f:
+        return json.load(f)


### PR DESCRIPTION
## What has changed
Instead of using different flags like simulation / use_enc_odom, we switch to using specific modes (autonav, autonav_sim, self_drive etc.) to launch nodes. The configurations we need have meaningfully diverged between the different modes (i.e. testing requires encoder odom and identity map -> base_link, while autonav needs full EKF). Instead of having to know the configuration for each mode we should just encode that as a parameter

Also add helper functions to nav_bringup to clean up the code 

## Testing plan
Tested each mode and launch file configuration locally