### PR TITLE
Fix setup script failure when initializing vectornav and when apt cache is stale

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -35,13 +35,18 @@ if [[ ! -d "$WS_ROOT/src" ]]; then
 fi
 
 log "Initializing git submodules"
-git -C "$REPO_ROOT" submodule update --init --recursive
+submodule_output=$(git -C "$REPO_ROOT" submodule update --init --recursive)
+if [[ -n "$submodule_output" ]]; then
+  log "Submodules changed — clearing build, install, and log directories"
+  rm -rf "$WS_ROOT/build" "$WS_ROOT/install" "$WS_ROOT/log"
+fi
 
 log "Installing Python tooling deps"
 python3 -m pip install -U pip
 python3 -m pip install -e "$REPO_ROOT[tooling]"
 
 log "Installing ROS deps via rosdep"
+sudo apt update
 rosdep update
 rosdep install --from-paths "$REPO_ROOT" --ignore-src -r -y
 


### PR DESCRIPTION
Closes #91 
Closes #89 

## What has changed
1. Add `sudo apt update` before calling `rosdep update`
2. Add a check for submodule and delete build, install log if any new submodules are installed

## Testing plan
Ran setup script on clean repo:
```
==> Initializing git submodules
Submodule 'imu_publisher' (https://github.com/RobotnikAutomation/vectornav.git) registered for path 'imu_publisher'
Cloning into '/home/ryanl/Desktop/ws/src/nav_stack/imu_publisher'...

==> Submodules changed — clearing build, install, and log directories
```