### PR TITLE
Fix assert_never missing in Python 3.10

### DIFF
--- a/nav_bringup/launch/localization.launch.py
+++ b/nav_bringup/launch/localization.launch.py
@@ -98,7 +98,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         case "nav_test":
             return [enc_odom_node, identity_map_odom_node]
         case _:
-            raise ValueError(f"Invalid mode: {mode}")
+            assert_never(mode)  # type: ignore[unreachable]
 
 
 def generate_launch_description() -> LaunchDescription:

--- a/nav_bringup/launch/localization.launch.py
+++ b/nav_bringup/launch/localization.launch.py
@@ -3,6 +3,7 @@ from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from nav_bringup.launch_utils import MODES, Mode, bringup_share, format_mode_description, load_frames, load_gps_file
+from typing_extensions import assert_never
 
 
 def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
@@ -98,7 +99,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         case "nav_test":
             return [enc_odom_node, identity_map_odom_node]
         case _:
-            assert_never(mode)  # type: ignore[unreachable]
+            assert_never(mode)
 
 
 def generate_launch_description() -> LaunchDescription:

--- a/nav_bringup/launch/navigation.launch.py
+++ b/nav_bringup/launch/navigation.launch.py
@@ -3,6 +3,7 @@ from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from nav_bringup.launch_utils import MODES, Mode, bringup_share, format_mode_description, load_frames
+from typing_extensions import assert_never
 
 
 def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
@@ -84,7 +85,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         case "nav_test":
             return [occupancy_grid_transform_node, path_tracking_node, path_planning_node]
         case _:
-            assert_never(mode)  # type: ignore[unreachable]
+            assert_never(mode)
 
 
 def generate_launch_description() -> LaunchDescription:

--- a/nav_bringup/launch/navigation.launch.py
+++ b/nav_bringup/launch/navigation.launch.py
@@ -84,7 +84,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         case "nav_test":
             return [occupancy_grid_transform_node, path_tracking_node, path_planning_node]
         case _:
-            raise ValueError(f"Invalid mode: {mode}")
+            assert_never(mode)  # type: ignore[unreachable]
 
 
 def generate_launch_description() -> LaunchDescription:

--- a/nav_bringup/launch/sensors.launch.py
+++ b/nav_bringup/launch/sensors.launch.py
@@ -94,7 +94,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         case "nav_test":
             return []
         case _:
-            raise ValueError(f"Invalid mode: {mode}")
+            assert_never(mode)  # type: ignore[unreachable]
 
 
 def generate_launch_description() -> LaunchDescription:

--- a/nav_bringup/launch/sensors.launch.py
+++ b/nav_bringup/launch/sensors.launch.py
@@ -3,6 +3,7 @@ from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from nav_bringup.launch_utils import MODES, Mode, bringup_share, format_mode_description, load_frames, load_gps_file
+from typing_extensions import assert_never
 
 
 def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
@@ -94,7 +95,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         case "nav_test":
             return []
         case _:
-            assert_never(mode)  # type: ignore[unreachable]
+            assert_never(mode)
 
 
 def generate_launch_description() -> LaunchDescription:

--- a/nav_bringup/package.xml
+++ b/nav_bringup/package.xml
@@ -26,6 +26,7 @@
   <exec_depend>twist_mux</exec_depend>
   <exec_depend>state_machine</exec_depend>
   <exec_depend>foxglove_bridge</exec_depend>
+  <exec_depend>python3-typing-extensions</exec_depend>
 
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>


### PR DESCRIPTION
Closes #99 

## What has changed
Add in the python3-typing-extensions module which backports assert_never into 3.10 so that exhaustiveness checking works

## Testing plan
Tested locally by running launch field and running check script with a branch removed 