### PR TITLE
Fix PS4 teleop axis

### DIFF
--- a/nav_bringup/config/teleop/teleop_ps4.yaml
+++ b/nav_bringup/config/teleop/teleop_ps4.yaml
@@ -7,7 +7,7 @@ joy:
 teleop_twist_joy:
   ros__parameters:
     axis_linear:
-      x: 0.5
+      x: 1
     scale_linear:
       x: 1.5
     scale_linear_turbo:

--- a/nav_bringup/config/teleop/teleop_ps4.yaml
+++ b/nav_bringup/config/teleop/teleop_ps4.yaml
@@ -9,9 +9,9 @@ teleop_twist_joy:
     axis_linear:
       x: 1
     scale_linear:
-      x: 1.5
+      x: 0.5
     scale_linear_turbo:
-      x: 2.0
+      x: 1.5
 
     axis_angular:
       yaw: 3


### PR DESCRIPTION
Makes the PS4 config not crash and match xbox config.

I am very confused about why this happened. This was changed [during a field test](https://github.com/umigv/nav_stack/commit/043cd76ffb0292344a69b2a4678c936cf41ee446) meaning the code must've worked with an actual controller even though it shouldn't have