### PR TITLE
Remove foxglove bridge (drop once fixed after 3/27/2026)

### DIFF
--- a/nav_bringup/launch/core.launch.py
+++ b/nav_bringup/launch/core.launch.py
@@ -62,22 +62,5 @@ def generate_launch_description() -> LaunchDescription:
                     ("cmd_vel_out", "cmd_vel"),
                 ],
             ),
-            Node(
-                package="foxglove_bridge",
-                executable="foxglove_bridge",
-                name="foxglove_bridge",
-                output="screen",
-                parameters=[
-                    {"port": 8765},
-                    {"address": "0.0.0.0"},
-                    {"tls": False},
-                    {"topic_whitelist": [".*"]},
-                    {"param_whitelist": [".*"]},
-                    {"service_whitelist": [".*"]},
-                    {"send_buffer_limit": 10000000},
-                    {"use_sim_time": False},
-                    {"num_threads": 4},
-                ],
-            ),
         ]
     )

--- a/nav_bringup/package.xml
+++ b/nav_bringup/package.xml
@@ -25,7 +25,6 @@
   <exec_depend>teleop_twist_joy</exec_depend>
   <exec_depend>twist_mux</exec_depend>
   <exec_depend>state_machine</exec_depend>
-  <exec_depend>foxglove_bridge</exec_depend>
   <exec_depend>python3-typing-extensions</exec_depend>
 
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
Closed #103 

## What has changed
Pin ROS apt repository to the latest working repo such that foxglove bridge can be properly installed. This should be reverted / dropped once the fix is complete 

## Testing plan
Tested on CI and locally