### PR TITLE
Separate mode and simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can install all dependencies by running
 ## Running the stack
 Run each of these commands in separate terminals:
 ```bash
-ros2 launch nav_bringup base.launch.py mode:=<mode> [course:=<course>]
+ros2 launch nav_bringup base.launch.py mode:=<mode> [simulation:=true] [course:=<course>]
 ```
 ```bash
 ros2 launch nav_bringup teleop.launch.py controller:=<ps4/xbox>

--- a/nav_bringup/README.md
+++ b/nav_bringup/README.md
@@ -3,13 +3,14 @@ Launch files and configuration for the navigation stack.
 
 
 ## Modes
-| Mode | Sensors | `odom`→`base_link` | `map`→`odom` | /goal source | `course` required |
-|---|---|---|---|---|---|
-| `autonav` | IMU + GPS | EKF | EKF | autonav_goal_selection | yes |
-| `autonav_sim` | simulated | EKF | EKF | autonav_goal_selection | yes |
-| `self_drive` | IMU | EKF | identity | CV | no |
-| `self_drive_sim` | simulated | EKF | identity | CV | yes |
-| `nav_test` | none | enc_odom | identity | manual | no |
+| Mode | `odom`→`base_link` | `map`→`odom` | /goal source |
+|---|---|---|---|
+| `autonav` | EKF | EKF | autonav_goal_selection |
+| `self_drive` | EKF | identity | CV |
+| `nav_test` | enc_odom | identity | manual |
+
+Pass `simulation:=true` to use simulated sensors instead of hardware. `course` is required for `autonav` and when 
+`simulation:=true`.
 
 
 ### Course Configuration
@@ -23,16 +24,16 @@ course is used when no `course` argument is provided. See `nav_bringup/courses/d
 
 
 ## base.launch.py
-Launches the base stack required for all operation modes: core, sensors, and localization.
+Launches the base stack required for all operation modes: core, hardware/simulation, and localization.
 
 ```
-ros2 launch nav_bringup base.launch.py mode:=<mode> [course:=<course>]
+ros2 launch nav_bringup base.launch.py mode:=<mode> [simulation:=true] [course:=<course>]
 ```
 
 ### Parameters
-- `mode`: Operation mode, passed through to sensors.launch.py and localization.launch.py (required)
-- `course`: Course profile, passed through to sensors.launch.py and localization.launch.py, default `default` (required 
-for `autonav`, `autonav_sim`, `self_drive_sim`)
+- `mode`: Operation mode, passed through to hardware/simulation and localization launch files (required)
+- `simulation`: Use simulation instead of hardware sensors, default `false`
+- `course`: Course profile, default `default` (required for `mode:=autonav` or `simulation:=true`)
 
 
 ## core.launch.py
@@ -76,35 +77,44 @@ See `marvin_description` for the full list of published frames.
 If a higher-priority source stops publishing, control falls back to the next source after 0.5s.
 
 
-## sensors.launch.py
-Launches sensor drivers
+## hardware.launch.py
+Launches hardware drivers
 
 ```
-ros2 launch nav_bringup sensors.launch.py mode:=<mode> [course:=<course>]
+ros2 launch nav_bringup hardware.launch.py mode:=<mode>
 ```
 
 ### Parameters
 - `mode`: Operation mode (required)
-- `course`: Course profile in `courses/` to load map and GPS datum from, default `default` (required for `autonav_sim`, 
-`self_drive_sim`)
 
-### Published Topics (Hardware)
+### Published Topics
 - `imu/raw` (`sensor_msgs/Imu`) - Raw IMU data from VectorNav (`autonav`, `self_drive`)
 - `gps/raw` (`sensor_msgs/NavSatFix`) - Raw GPS fix from GPS receiver (`autonav` only)
 
-### Subscribed Topics (Simulation)
+
+## simulation.launch.py
+Launches simulated sensors. Included by `base.launch.py` when `simulation:=true`.
+
+```
+ros2 launch nav_bringup simulation.launch.py [course:=<course>]
+```
+
+### Parameters
+- `course`: Course profile in `courses/` to load map and GPS datum from, default `default`
+
+### Subscribed Topics
 - `cmd_vel` (`geometry_msgs/Twist`) - Velocity the robot is commanded to move in
 
-### Published Topics (Simulation)
+### Published Topics
 - `imu/raw` (`sensor_msgs/Imu`) - Simulated IMU with Gaussian noise
 - `gps/raw` (`sensor_msgs/NavSatFix`) - Simulated GPS with noise and OU drift
 - `enc_vel/raw` (`geometry_msgs/TwistWithCovarianceStamped`) - Simulated encoder velocity with noise and OU drift
-- `odom/ground_truth` (`nav_msgs/Odometry`) - Noiseless true pose in `map` frame
+- `odom/ground_truth` (`nav_msgs/Odometry`) - Noiseless true pose in `map` frame 
 (`child_frame_id = base_link_ground_truth`)
 - `occupancy_grid/raw` (`nav_msgs/OccupancyGrid`) - Robot-centric occupancy grid from static obstacle map
 - `occupancy_grid/ground_truth` (`nav_msgs/OccupancyGrid`) - Full static obstacle map (latched)
 
-### Broadcasted TF Frames (Simulation)
+### Broadcasted TF Frames
 - `map` → `base_link_ground_truth` - Noiseless true robot pose
 
 
@@ -135,24 +145,23 @@ Uses the standard `robot_localization` dual-EKF pattern:
 
 ### Parameters
 - `mode`: Operation mode (required)
-- `course`: Course profile in `courses/` to load GPS datum from, default `default` (required for `autonav`, 
-`autonav_sim`)
+- `course`: Course profile in `courses/` to load GPS datum from, default `default` (required for `autonav`)
 
 ### Subscribed Topics
-- `imu/raw` (`sensor_msgs/Imu`) - Raw IMU data (autonav*, self_drive* only)
-- `gps/raw` (`sensor_msgs/NavSatFix`) - Raw GPS fix (autonav* only)
+- `imu/raw` (`sensor_msgs/Imu`) - Raw IMU data (autonav, self_drive only)
+- `gps/raw` (`sensor_msgs/NavSatFix`) - Raw GPS fix (autonav only)
 - `enc_vel/raw` (`geometry_msgs/TwistWithCovarianceStamped`) - Encoder velocity
 
 ### Published Topics
 - `odom/local` (`nav_msgs/Odometry`) - Local odometry in the odom frame
-- `odom/global` (`nav_msgs/Odometry`) - Global odometry in the map frame (autonav* only)
+- `odom/global` (`nav_msgs/Odometry`) - Global odometry in the map frame (autonav only)
 
 ### Broadcasted TF Frames
 - `odom` → `base_link`
 - `map` → `odom`
 
 ### Services
-- `fromLL` (`robot_localization/FromLL`) - Converts GPS latitude/longitude to a map-frame point (autonav* only)
+- `fromLL` (`robot_localization/FromLL`) - Converts GPS latitude/longitude to a map-frame point (autonav only)
 
 
 ## navigation.launch.py
@@ -164,20 +173,21 @@ ros2 launch nav_bringup navigation.launch.py mode:=<mode> [course:=<course>]
 
 ### Parameters
 - `mode`: Operation mode (required)
-- `course`: Course profile in `courses/` to load waypoints from, default `default` (required for autonav, autonav_sim)
+- `course`: Course profile in `courses/` to load waypoints from, default `default` (required for `autonav`)
 
 ### Subscribed Topics
-- `goal` (`geometry_msgs/PointStamped`) - Goal for path planning (`self_drive`, `self_drive_sim`, `nav_test` only)
+- `goal` (`geometry_msgs/PointStamped`) - Goal for path planning (`self_drive`, `nav_test` only)
 - `occupancy_grid/raw` (`nav_msgs/OccupancyGrid`) - Raw occupancy grid from CV
 - `odom/local` (`nav_msgs/Odometry`) - Odometry from localization
 
 ### Published Topics
-- `goal` (`geometry_msgs/PointStamped`) - Goal for path planning (`autonav`, `autonav_sim` only)
-- `gps_waypoint` (`geometry_msgs/PointStamped`) - Current GPS waypoint target (`autonav`, `autonav_sim` only)
+- `goal` (`geometry_msgs/PointStamped`) - Goal for path planning (`autonav` only)
+- `gps_waypoint` (`geometry_msgs/PointStamped`) - Current GPS waypoint target (`autonav` only)
 - `nav_cmd_vel` (`geometry_msgs/Twist`) - Velocity command consumed by twist_mux
 
 ### Service Clients
-- `fromLL` (`robot_localization/FromLL`) - Converts GPS coordinates to map-frame points; called at startup by autonav_goal_selection (`autonav`, `autonav_sim` only)
+- `fromLL` (`robot_localization/FromLL`) - Converts GPS coordinates to map-frame points; called at startup by 
+autonav_goal_selection (`autonav` only)
 
 
 ## teleop.launch.py

--- a/nav_bringup/launch/base.launch.py
+++ b/nav_bringup/launch/base.launch.py
@@ -1,5 +1,6 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.conditions import IfCondition, UnlessCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
@@ -14,20 +15,33 @@ def generate_launch_description() -> LaunchDescription:
             DeclareLaunchArgument(
                 "mode",
                 choices=MODES,
-                description="Operation mode, passed through to sensors.launch.py and localization.launch.py",
+                description="Operation mode, passed through to hardware/simulation and localization launch files",
+            ),
+            DeclareLaunchArgument(
+                "simulation",
+                default_value="false",
+                choices=["true", "false"],
+                description="Use simulation instead of hardware sensors",
             ),
             DeclareLaunchArgument(
                 "course",
                 default_value="default",
-                description="Course profile, passed through to sensors.launch.py and localization.launch.py (required for autonav, autonav_sim, self_drive_sim)",
+                description="Course profile (required for mode:=autonav or simulation:=true)",
             ),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(PathJoinSubstitution([bringup_share, "launch", "core.launch.py"])),
             ),
             IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(PathJoinSubstitution([bringup_share, "launch", "sensors.launch.py"])),
+                PythonLaunchDescriptionSource(PathJoinSubstitution([bringup_share, "launch", "hardware.launch.py"])),
+                condition=UnlessCondition(LaunchConfiguration("simulation")),
                 launch_arguments=[
                     ("mode", LaunchConfiguration("mode")),
+                ],
+            ),
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource(PathJoinSubstitution([bringup_share, "launch", "simulation.launch.py"])),
+                condition=IfCondition(LaunchConfiguration("simulation")),
+                launch_arguments=[
                     ("course", LaunchConfiguration("course")),
                 ],
             ),

--- a/nav_bringup/launch/hardware.launch.py
+++ b/nav_bringup/launch/hardware.launch.py
@@ -1,0 +1,70 @@
+from launch import LaunchDescription, LaunchDescriptionEntity
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from nav_bringup.launch_utils import MODES, Mode, bringup_share, format_mode_description, load_frames
+from typing_extensions import assert_never
+
+
+def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
+    frames = load_frames()
+    mode: Mode = LaunchConfiguration("mode").perform(context)
+    share = bringup_share()
+
+    imu_node = Node(
+        package="vectornav",
+        executable="vectornav_node",
+        name="vectornav",
+        output="screen",
+        parameters=[
+            f"{share}/config/sensors/imu.yaml",
+            {"frame_id": frames["imu_frame"]},
+            {"map_frame_id": frames["map_frame"]},
+        ],
+        remappings=[
+            ("vectornav/data", "imu/raw"),
+        ],
+    )
+
+    gps_node = Node(
+        package="gps_publisher",
+        executable="gps_publisher",
+        name="gps_publisher",
+        output="screen",
+        parameters=[
+            f"{share}/config/sensors/gps.yaml",
+            {"gps_frame_id": frames["gps_frame"]},
+        ],
+        remappings=[
+            ("gps", "gps/raw"),
+        ],
+    )
+
+    match mode:
+        case "autonav":
+            return [imu_node, gps_node]
+        case "self_drive":
+            return [imu_node]
+        case "nav_test":
+            return []
+        case _:
+            assert_never(mode)
+
+
+def generate_launch_description() -> LaunchDescription:
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "mode",
+                choices=MODES,
+                description=format_mode_description(
+                    {
+                        "autonav": "IMU + GPS",
+                        "self_drive": "IMU only",
+                        "nav_test": "no sensors",
+                    }
+                ),
+            ),
+            OpaqueFunction(function=launch_setup),
+        ]
+    )

--- a/nav_bringup/launch/localization.launch.py
+++ b/nav_bringup/launch/localization.launch.py
@@ -90,11 +90,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
     match mode:
         case "autonav":
             return [ekf_local_node, navsat_transform_node, ekf_global_node]
-        case "autonav_sim":
-            return [ekf_local_node, navsat_transform_node, ekf_global_node]
         case "self_drive":
-            return [ekf_local_node, identity_map_odom_node]
-        case "self_drive_sim":
             return [ekf_local_node, identity_map_odom_node]
         case "nav_test":
             return [enc_odom_node, identity_map_odom_node]
@@ -111,9 +107,7 @@ def generate_launch_description() -> LaunchDescription:
                 description=format_mode_description(
                     {
                         "autonav": "EKF local + navsat transform + EKF global",
-                        "autonav_sim": "EKF local + navsat transform + EKF global",
                         "self_drive": "EKF local + identity map->odom",
-                        "self_drive_sim": "EKF local + identity map->odom",
                         "nav_test": "enc_odom + identity map->odom",
                     }
                 ),

--- a/nav_bringup/launch/localization.launch.py
+++ b/nav_bringup/launch/localization.launch.py
@@ -84,7 +84,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         executable="static_transform_publisher",
         name="map_odom_publisher",
         output="screen",
-        arguments=["0", "0", "0", "0", "0", "0", frames["map_frame"], frames["odom_frame"]],
+        arguments=["--frame-id", frames["map_frame"], "--child-frame-id", frames["odom_frame"]],
     )
 
     match mode:

--- a/nav_bringup/launch/navigation.launch.py
+++ b/nav_bringup/launch/navigation.launch.py
@@ -76,13 +76,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
     match mode:
         case "autonav":
             return [occupancy_grid_transform_node, path_tracking_node, path_planning_node, autonav_goal_selection_node]
-        case "autonav_sim":
-            return [occupancy_grid_transform_node, path_tracking_node, path_planning_node, autonav_goal_selection_node]
-        case "self_drive":
-            return [occupancy_grid_transform_node, path_tracking_node, path_planning_node]
-        case "self_drive_sim":
-            return [occupancy_grid_transform_node, path_tracking_node, path_planning_node]
-        case "nav_test":
+        case "self_drive" | "nav_test":
             return [occupancy_grid_transform_node, path_tracking_node, path_planning_node]
         case _:
             assert_never(mode)
@@ -97,9 +91,7 @@ def generate_launch_description() -> LaunchDescription:
                 description=format_mode_description(
                     {
                         "autonav": "occupancy grid transform + path planning + path tracking + autonav goal selection",
-                        "autonav_sim": "occupancy grid transform + path planning + path tracking + autonav goal selection",
                         "self_drive": "occupancy grid transform + path planning + path tracking",
-                        "self_drive_sim": "occupancy grid transform + path planning + path tracking",
                         "nav_test": "occupancy grid transform + path planning + path tracking",
                     }
                 ),

--- a/nav_bringup/launch/simulation.launch.py
+++ b/nav_bringup/launch/simulation.launch.py
@@ -2,45 +2,14 @@ from launch import LaunchDescription, LaunchDescriptionEntity
 from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from nav_bringup.launch_utils import MODES, Mode, bringup_share, format_mode_description, load_frames, load_gps_file
-from typing_extensions import assert_never
+from nav_bringup.launch_utils import bringup_share, load_frames, load_gps_file
 
 
 def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
     frames = load_frames()
-    mode: Mode = LaunchConfiguration("mode").perform(context)
     course = LaunchConfiguration("course").perform(context)
-    gps_file = load_gps_file(course)
     share = bringup_share()
-
-    imu_node = Node(
-        package="vectornav",
-        executable="vectornav_node",
-        name="vectornav",
-        output="screen",
-        parameters=[
-            f"{share}/config/sensors/imu.yaml",
-            {"frame_id": frames["imu_frame"]},
-            {"map_frame_id": frames["map_frame"]},
-        ],
-        remappings=[
-            ("vectornav/data", "imu/raw"),
-        ],
-    )
-
-    gps_node = Node(
-        package="gps_publisher",
-        executable="gps_publisher",
-        name="gps_publisher",
-        output="screen",
-        parameters=[
-            f"{share}/config/sensors/gps.yaml",
-            {"gps_frame_id": frames["gps_frame"]},
-        ],
-        remappings=[
-            ("gps", "gps/raw"),
-        ],
-    )
+    gps_file = load_gps_file(course)
 
     sensor_simulator_node = Node(
         package="sensor_simulator",
@@ -83,41 +52,16 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         ],
     )
 
-    match mode:
-        case "autonav":
-            return [imu_node, gps_node]
-        case "autonav_sim":
-            return [sensor_simulator_node, occupancy_grid_simulator_node]
-        case "self_drive":
-            return [imu_node]
-        case "self_drive_sim":
-            return [sensor_simulator_node, occupancy_grid_simulator_node]
-        case "nav_test":
-            return []
-        case _:
-            assert_never(mode)
+    return [sensor_simulator_node, occupancy_grid_simulator_node]
 
 
 def generate_launch_description() -> LaunchDescription:
     return LaunchDescription(
         [
             DeclareLaunchArgument(
-                "mode",
-                choices=MODES,
-                description=format_mode_description(
-                    {
-                        "autonav": "IMU + GPS",
-                        "autonav_sim": "sensor simulator + occupancy grid simulator",
-                        "self_drive": "IMU only",
-                        "self_drive_sim": "sensor simulator + occupancy grid simulator",
-                        "nav_test": "no sensors",
-                    }
-                ),
-            ),
-            DeclareLaunchArgument(
                 "course",
                 default_value="default",
-                description="Course profile in courses/ to load map and GPS datum from (required for autonav_sim, self_drive_sim)",
+                description="Course profile in courses/ to load map and GPS datum from",
             ),
             OpaqueFunction(function=launch_setup),
         ]

--- a/nav_bringup/nav_bringup/launch_utils.py
+++ b/nav_bringup/nav_bringup/launch_utils.py
@@ -4,7 +4,7 @@ from typing import Literal, get_args
 import yaml
 from ament_index_python.packages import get_package_share_directory
 
-Mode = Literal["autonav", "autonav_sim", "self_drive", "self_drive_sim", "nav_test"]
+Mode = Literal["autonav", "self_drive", "nav_test"]
 MODES: list[Mode] = list(get_args(Mode))
 
 


### PR DESCRIPTION
## What has changed
- Split the 5 modes (autonav_sim, autonav, self_drive_sim, self_drive, nav_test) into mode (autonav, self_drive, nav_test) and a simulation flag. This avoids cartesian explosion when we add more configs
- Split sensors.launch.py into hardware.launch.py and simulation.launch.py

## Testing plan
Ran all launch files with all args and verified that the correct nodes are launched