### PR TITLE
Remove submodule cloning in CI build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,8 +17,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Log in to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## What has changed
We have a private repo that's causing a CI failure from being unable to clone. We don't use the vectornav driver anywhere in CI so let's just remove it

## Testing Plan
Ran CI which passed: https://github.com/umigv/nav_stack/actions/runs/24413398649