### PR TITLE
Make inflation falloff additive to hard radius, retune defaults

### DIFF
--- a/occupancy_grid_transform/README.md
+++ b/occupancy_grid_transform/README.md
@@ -22,8 +22,8 @@ The occupancy grid from CV is expected to match the convention of
 After the grid is converted and a border is added, obstacle inflation is applied. For each occupied cell, surrounding
 cells are inflated based on their distance:
 - Cells within `inflation_radius_cells` are set to fully occupied (100)
-- Cells between `inflation_radius_cells` and `inflation_falloff_radius_cells` decay as `100 × decay^(dist - radius)`
-- Cells beyond `inflation_falloff_radius_cells` are unaffected
+- Cells in the next `inflation_falloff_extent_cells` ring decay as `100 × decay^(dist - inflation_radius_cells)`
+- Cells beyond `inflation_radius_cells + inflation_falloff_extent_cells` are unaffected
 
 ## Config Parameters
 | Parameter | Default | Description |
@@ -33,6 +33,6 @@ cells are inflated based on their distance:
 ### Inflation Parameters (`inflation_params`)
 | Parameter | Default | Description |
 |---|---|---|
-| `inflation_radius_cells` | `10` | Radius (cells) of the fully inflated obstacle core |
-| `inflation_falloff_radius_cells` | `20` | Maximum radius (cells) of obstacle influence |
+| `inflation_radius_cells` | `12` | Radius (cells) of the fully inflated obstacle core |
+| `inflation_falloff_extent_cells` | `0` | Extent (cells) of the falloff region applied beyond the hard core |
 | `inflation_decay_factor` | `0.9` | Decay factor in the falloff region (0–1, higher = slower decay) |

--- a/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform_config.py
+++ b/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform_config.py
@@ -12,24 +12,22 @@ class InflationParams:
         inflation_radius_cells: Radius (in grid cells) of the fully inflated obstacle core. All cells within this
             distance of an occupied cell are treated as maximally inflated, preventing planners from routing paths
             too close to obstacles.
-        inflation_falloff_radius_cells: Maximum radius (in grid cells) of obstacle influence. Beyond
-            `inflation_radius_cells`, obstacle influence decays until this radius is reached. Cells outside this
-            radius are unaffected by inflation.
+        inflation_falloff_extent_cells: Extent (in grid cells) of the falloff region applied beyond the hard core.
+            Obstacle influence decays with distance across this region. The total radius of obstacle influence is
+            `inflation_radius_cells + inflation_falloff_extent_cells`. Set to 0 to disable the falloff region.
         inflation_decay_factor: Decay factor applied to obstacle influence in the falloff region. Values closer to
             1.0 result in slower decay and more conservative paths; values closer to 0.0 decay more aggressively.
     """
 
-    inflation_radius_cells: int = 6
-    inflation_falloff_radius_cells: int = 6
+    inflation_radius_cells: int = 12
+    inflation_falloff_extent_cells: int = 0
     inflation_decay_factor: float = 0.9
 
     def __post_init__(self) -> None:
         if self.inflation_radius_cells < 0:
             raise ValueError("InflationParams: inflation_radius_cells must be >= 0")
-        if self.inflation_falloff_radius_cells < 0:
-            raise ValueError("InflationParams: inflation_falloff_radius_cells must be >= 0")
-        if self.inflation_radius_cells > self.inflation_falloff_radius_cells:
-            raise ValueError("InflationParams: inflation_falloff_radius_cells must be >= inflation_radius_cells")
+        if self.inflation_falloff_extent_cells < 0:
+            raise ValueError("InflationParams: inflation_falloff_extent_cells must be >= 0")
         if not (0 < self.inflation_decay_factor < 1):
             raise ValueError("InflationParams: inflation_decay_factor must be between 0 and 1")
 

--- a/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform_impl.py
+++ b/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform_impl.py
@@ -26,14 +26,15 @@ def add_border(grid: np.ndarray) -> np.ndarray:
 
 
 @lru_cache(maxsize=1)
-def _make_inflation_kernel(r_hard: int, r_soft: int, decay: float) -> np.ndarray:
-    """Precompute a (2*r_soft+1) x (2*r_soft+1) kernel of inflation values."""
-    ys, xs = np.mgrid[-r_soft : r_soft + 1, -r_soft : r_soft + 1]
+def _make_inflation_kernel(r_hard: int, extent_soft: int, decay: float) -> np.ndarray:
+    """Precompute a (2*r_total+1) x (2*r_total+1) kernel of inflation values, where r_total = r_hard + extent_soft."""
+    r_total = r_hard + extent_soft
+    ys, xs = np.mgrid[-r_total : r_total + 1, -r_total : r_total + 1]
     dists = np.hypot(xs, ys)
     kernel = np.where(
         dists <= r_hard,
         100,
-        np.where(dists <= r_soft, np.round(100.0 * decay ** (dists - r_hard)), 0),
+        np.where(dists <= r_total, np.round(100.0 * decay ** (dists - r_hard)), 0),
     ).astype(np.int8)
     return kernel
 
@@ -52,20 +53,21 @@ def inflate_grid(grid: np.ndarray, params: InflationParams) -> np.ndarray:
         A new 2D `np.ndarray` (dtype `int8`) of the same shape containing the inflated occupancy values.
     """
     r_hard = params.inflation_radius_cells
-    r_soft = params.inflation_falloff_radius_cells
+    extent_soft = params.inflation_falloff_extent_cells
+    r_total = r_hard + extent_soft
     decay = params.inflation_decay_factor
     height, width = grid.shape
 
-    kernel = _make_inflation_kernel(r_hard, r_soft, decay)
+    kernel = _make_inflation_kernel(r_hard, extent_soft, decay)
     output = grid.astype(np.int8, copy=True)
 
     ys, xs = np.where(grid == 100)
     for y, x in zip(ys.tolist(), xs.tolist(), strict=True):
-        y0, y1 = max(0, y - r_soft), min(height, y + r_soft + 1)
-        x0, x1 = max(0, x - r_soft), min(width, x + r_soft + 1)
+        y0, y1 = max(0, y - r_total), min(height, y + r_total + 1)
+        x0, x1 = max(0, x - r_total), min(width, x + r_total + 1)
 
-        ky0, ky1 = y0 - (y - r_soft), y1 - (y - r_soft)
-        kx0, kx1 = x0 - (x - r_soft), x1 - (x - r_soft)
+        ky0, ky1 = y0 - (y - r_total), y1 - (y - r_total)
+        kx0, kx1 = x0 - (x - r_total), x1 - (x - r_total)
         np.maximum(output[y0:y1, x0:x1], kernel[ky0:ky1, kx0:kx1], out=output[y0:y1, x0:x1])
 
     return output

--- a/occupancy_grid_transform/test/test_occupancy_grid_transform_impl.py
+++ b/occupancy_grid_transform/test/test_occupancy_grid_transform_impl.py
@@ -24,7 +24,7 @@ def test_add_border():
 def test_inflate_grid():
     params = InflationParams(
         inflation_radius_cells=1,
-        inflation_falloff_radius_cells=2,
+        inflation_falloff_extent_cells=1,
         inflation_decay_factor=0.5,
     )
 


### PR DESCRIPTION
## What has changed
1. Increase default inflation radius from 6 to 12
2. Make inflation falloff additive instead of radius to make tuning easier

## Testing plan
No regression in unit test. Defaults tested with robot today