### PR TITLE
Use midpoint integration for encoder odom and publish at consistent rate

### DIFF
--- a/enc_odom_publisher/enc_odom_publisher/enc_odom_publisher.py
+++ b/enc_odom_publisher/enc_odom_publisher/enc_odom_publisher.py
@@ -5,7 +5,6 @@ from geometry_msgs.msg import (
     PoseWithCovariance,
     Transform,
     TransformStamped,
-    Twist,
     TwistWithCovariance,
     TwistWithCovarianceStamped,
     Vector3,
@@ -32,9 +31,12 @@ class EncOdomPublisher(Node):
 
         self.tf_broadcaster = TransformBroadcaster(self)
 
+        self.create_timer(self.config.publish_period_s, self.publish_odom)
+
         self.position = Point2d(x=0.0, y=0.0)
         self.rotation = Rotation2d(angle=0.0)
         self.prev_time: Time | None = None
+        self.twist = TwistWithCovariance()
 
         # Row-major 6x6 covariance [x, y, z, roll, pitch, yaw]
         self.pose_covariance = [0.0] * 36
@@ -58,45 +60,48 @@ class EncOdomPublisher(Node):
 
             linear_vel = msg.twist.twist.linear.x
             angular_vel = msg.twist.twist.angular.z
+            mid_rotation = self.rotation + Rotation2d(0.5 * angular_vel * dt)
 
-            self.position += Point2d(x=linear_vel * dt, y=0.0).rotate_by(self.rotation)
-            self.rotation = Rotation2d(self.rotation.angle + angular_vel * dt)
-
-            stamp = current_time.to_msg()
-
-            self.tf_broadcaster.sendTransform(
-                TransformStamped(
-                    header=Header(stamp=stamp, frame_id=self.config.odom_frame_id),
-                    child_frame_id=self.config.base_frame_id,
-                    transform=Transform(
-                        translation=Vector3(x=self.position.x, y=self.position.y, z=0.0),
-                        rotation=self.rotation.to_ros(),
-                    ),
-                )
-            )
-
-            self.odom_publisher.publish(
-                Odometry(
-                    header=Header(stamp=stamp, frame_id=self.config.odom_frame_id),
-                    child_frame_id=self.config.base_frame_id,
-                    pose=PoseWithCovariance(
-                        pose=Pose(
-                            position=self.position.to_ros(),
-                            orientation=self.rotation.to_ros(),
-                        ),
-                        covariance=self.pose_covariance,
-                    ),
-                    twist=TwistWithCovariance(
-                        twist=Twist(
-                            linear=Vector3(x=linear_vel),
-                            angular=Vector3(z=angular_vel),
-                        ),
-                        covariance=msg.twist.covariance,
-                    ),
-                )
-            )
+            self.position += Point2d(x=linear_vel * dt, y=0.0).rotate_by(mid_rotation)
+            self.rotation = mid_rotation + Rotation2d(0.5 * angular_vel * dt)
         finally:
+            self.twist = msg.twist
             self.prev_time = current_time
+
+    def publish_odom(self) -> None:
+        now = self.get_clock().now()
+
+        if self.prev_time is not None:
+            age_s = (now - self.prev_time).nanoseconds * 1e-9
+            twist = self.twist if age_s <= self.config.max_dt_s else TwistWithCovariance()
+        else:
+            twist = TwistWithCovariance()
+
+        self.tf_broadcaster.sendTransform(
+            TransformStamped(
+                header=Header(stamp=now.to_msg(), frame_id=self.config.odom_frame_id),
+                child_frame_id=self.config.base_frame_id,
+                transform=Transform(
+                    translation=Vector3(x=self.position.x, y=self.position.y, z=0.0),
+                    rotation=self.rotation.to_ros(),
+                ),
+            )
+        )
+
+        self.odom_publisher.publish(
+            Odometry(
+                header=Header(stamp=now.to_msg(), frame_id=self.config.odom_frame_id),
+                child_frame_id=self.config.base_frame_id,
+                pose=PoseWithCovariance(
+                    pose=Pose(
+                        position=self.position.to_ros(),
+                        orientation=self.rotation.to_ros(),
+                    ),
+                    covariance=self.pose_covariance,
+                ),
+                twist=twist,
+            )
+        )
 
 
 def main() -> None:

--- a/enc_odom_publisher/enc_odom_publisher/enc_odom_publisher.py
+++ b/enc_odom_publisher/enc_odom_publisher/enc_odom_publisher.py
@@ -58,6 +58,7 @@ class EncOdomPublisher(Node):
             if dt <= 0.0 or dt > self.config.max_dt_s:
                 return
 
+            # Use midpoint method for higher numerical accuracy: https://en.wikipedia.org/wiki/Midpoint_method
             linear_vel = msg.twist.twist.linear.x
             angular_vel = msg.twist.twist.angular.z
             mid_rotation = self.rotation + Rotation2d(0.5 * angular_vel * dt)

--- a/enc_odom_publisher/enc_odom_publisher/enc_odom_publisher_config.py
+++ b/enc_odom_publisher/enc_odom_publisher/enc_odom_publisher_config.py
@@ -10,6 +10,7 @@ class EncOdomPublisherConfig:
         pose_y_variance_m2: Pose covariance for y (m²).
         pose_yaw_variance_rad2: Pose covariance for yaw (rad²).
         max_dt_s: Maximum allowed dt (s) between encoder messages; updates exceeding this are dropped.
+        publish_period_s: Period (s) at which odom and TF are published.
         odom_frame_id: Parent frame for odometry and TF.
         base_frame_id: Child frame for odometry and TF.
     """
@@ -18,6 +19,7 @@ class EncOdomPublisherConfig:
     pose_y_variance_m2: float = 0.01
     pose_yaw_variance_rad2: float = 0.01
     max_dt_s: float = 1.0
+    publish_period_s: float = 0.01
     odom_frame_id: str = "odom"
     base_frame_id: str = "base_link"
 
@@ -30,3 +32,5 @@ class EncOdomPublisherConfig:
             raise ValueError("EncOdomPublisherConfig: pose_yaw_variance_rad2 must be > 0")
         if self.max_dt_s <= 0:
             raise ValueError("EncOdomPublisherConfig: max_dt_s must be > 0")
+        if self.publish_period_s <= 0:
+            raise ValueError("EncOdomPublisherConfig: publish_period_s must be > 0")


### PR DESCRIPTION
Closes #140 

## What has changed
1. Move odom publishing to a separate timer callback so the output is published at a consistent rate
2. Use [midpoint method](https://en.wikipedia.org/wiki/Midpoint_method) for higher integration accuracy

## Testing plan
Tested in simulation