### PR TITLE
Update Vectornav covariance from testing

### DIFF
--- a/nav_bringup/config/sensors/vectornav.yaml
+++ b/nav_bringup/config/sensors/vectornav.yaml
@@ -15,6 +15,6 @@ vectornav_driver:
                             0.0, 0.0, 0.01]
 
     # 3x3 row-major covariance matrix for angular velocity (rad/s)^2, in FLU body frame
-    angularVelCovariance: [0.001, 0.0, 0.0,
-                           0.0, 0.001, 0.0,
-                           0.0, 0.0, 0.001]
+    angularVelCovariance: [1e-5, 0.0, 0.0,
+                           0.0, 1e-5, 0.0,
+                           0.0, 0.0, 1e-5]


### PR DESCRIPTION
## What has changed
Set Vectornav covariance lower to be closer to odrive covariance (1e-6 static, 4e-5 per m/s)

## Testing plan
Tested during integration session today