### PR TITLE
Make ublox_driver more robust

### DIFF
--- a/ublox_driver/README.md
+++ b/ublox_driver/README.md
@@ -21,6 +21,7 @@ Covariance is filled using u-blox accuracy fields:
 | Parameter | Default | Description |
 |---|---|---|
 | `serial_port` | `/dev/ublox` | Serial port device path for the GPS receiver |
+| `baud_rate` | `460800` | Serial baud rate for communication |
 | `poll_period_s` | `0.1` | Period in seconds between GPS polls |
 | `ublox_frame_id` | `gps_link` | TF frame ID used in published GPS messages |
 

--- a/ublox_driver/ublox_driver/ublox_driver.py
+++ b/ublox_driver/ublox_driver/ublox_driver.py
@@ -2,11 +2,11 @@ from datetime import datetime, timezone
 
 import nav_utils.config
 import rclpy
+import serial
 from builtin_interfaces.msg import Time
 from pyubx2 import UBX_PROTOCOL, UBXMessage, UBXReader
 from rclpy.node import Node
 from sensor_msgs.msg import NavSatFix, NavSatStatus
-from serial import Serial
 from std_msgs.msg import Header
 
 from .ublox_driver_config import UbloxDriverConfig
@@ -23,8 +23,20 @@ class UbloxDriver(Node):
 
         self.publisher = self.create_publisher(NavSatFix, "ublox/gps", 10)
 
-        self.stream = Serial(self.config.serial_port, 460800, timeout=0.1)
-        self.ubx_reader = UBXReader(self.stream, protfilter=UBX_PROTOCOL)
+        self.serial: serial.Serial | None = None
+
+        try:
+            self.serial = serial.Serial(
+                str(self.config.serial_port), baudrate=self.config.baud_rate, timeout=self.config.poll_period_s
+            )
+            self.get_logger().info(f"Connected to {self.config.serial_port}")
+        except serial.SerialException as e:
+            self.get_logger().error(f"Failed to connect to {self.config.serial_port}: {e}")
+            # We don't call rclpy.shutdown() here because it causes a deadlock in humble
+            # https://github.com/ros2/rclpy/issues/1646
+            raise SystemExit(1) from None
+
+        self.ubx_reader = UBXReader(self.serial, protfilter=UBX_PROTOCOL)
 
         self.create_timer(self.config.poll_period_s, self.poll)
 
@@ -95,6 +107,11 @@ class UbloxDriver(Node):
             return Time(sec=int(seconds) - 1, nanosec=int(data.nano) + 1_000_000_000)
 
         return Time(sec=int(seconds), nanosec=int(data.nano))
+
+    def destroy_node(self) -> None:
+        if self.serial is not None and self.serial.is_open:
+            self.serial.close()
+        super().destroy_node()
 
 
 def main() -> None:

--- a/ublox_driver/ublox_driver/ublox_driver_config.py
+++ b/ublox_driver/ublox_driver/ublox_driver_config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from pathlib import Path
 
 
 @dataclass(frozen=True)
@@ -7,14 +8,18 @@ class UbloxDriverConfig:
 
     Attributes:
         serial_port: The serial port device path for the GPS receiver.
+        baud_rate: Serial baud rate for communication.
         poll_period_s: The period in seconds between GPS polls.
         ublox_frame_id: The TF frame ID to use in published GPS messages.
     """
 
-    serial_port: str = "/dev/ublox"
+    serial_port: Path = Path("/dev/ublox")
+    baud_rate: int = 460800
     poll_period_s: float = 0.1
     ublox_frame_id: str = "gps_link"
 
     def __post_init__(self) -> None:
+        if self.baud_rate <= 0:
+            raise ValueError("UbloxDriverConfig: baud_rate must be > 0")
         if self.poll_period_s <= 0:
             raise ValueError("UbloxDriverConfig: poll_period_s must be > 0")


### PR DESCRIPTION
## What has changed
1. Add baud rate as parameter and use path for serial port 
2. Add exception handling for serial exceptions
3. Close the port on exit so that we don't have a resource leak